### PR TITLE
Fix typo within "[...]-5861.map"

### DIFF
--- a/evtx/Maps/Microsoft-Windows-WMI-Activity_Operational_5861.map
+++ b/evtx/Maps/Microsoft-Windows-WMI-Activity_Operational_5861.map
@@ -12,7 +12,7 @@ Maps:
         Value: "/Event/UserData/Operation_ESStoConsumerBinding/ESS"
   - 
     Property: PayloadData2
-    PropertyValue: "%ESS%"
+    PropertyValue: "%PossibleCause%"
     Values: 
       - 
         Name: PossibleCause


### PR DESCRIPTION
"PayloadData2" property had "ESS" propertyvalue instead of "PossibleCause".