### PR TITLE
Map Microsoft-Windows-Partition%4Diagnostic.evtx for EventID 1006

### DIFF
--- a/evtx/Maps/Microsoft-Windows-Partition-Diagnostic_1006.map
+++ b/evtx/Maps/Microsoft-Windows-Partition-Diagnostic_1006.map
@@ -1,0 +1,33 @@
+Author: Mark Hallman mark.hallman@gmail.com
+Description: USB Insertation 1006 EventId
+EventId: 1006
+Channel: "Microsoft-Windows-Partition/Diagnostic"
+Maps: 
+  - 
+    Property: PayloadData1
+    PropertyValue: "Model: %Model%"
+    Values: 
+      - 
+        Name: Model
+        Value: "/Event/EventData/Data[@Name=\"Model\"]"
+  - 
+    Property: PayloadData2
+    PropertyValue: "SerialNumber: %SerialNumber%"
+    Values: 
+      - 
+        Name: SerialNumber
+        Value: "/Event/EventData/Data[@Name=\"SerialNumber\"]"
+  -
+    Property: PayloadData3
+    PropertyValue: "DiskId: %DiskId%"
+    Values: 
+      - 
+        Name: DiskId
+        Value: "/Event/EventData/Data[@Name=\"DiskId\"]"
+  -
+    Property: PayloadData4
+    PropertyValue: "ParentId: %ParentId%"
+    Values: 
+      - 
+        Name: ParentId
+        Value: "/Event/EventData/Data[@Name=\"ParentId\"]"

--- a/evtx/Maps/Microsoft-Windows-Partition-Diagnostic_1006.map
+++ b/evtx/Maps/Microsoft-Windows-Partition-Diagnostic_1006.map
@@ -1,5 +1,5 @@
 Author: Mark Hallman mark.hallman@gmail.com
-Description: USB Insertation 1006 EventId
+Description: USB Insertion/Removal - EventId 1006
 EventId: 1006
 Channel: "Microsoft-Windows-Partition/Diagnostic"
 Maps: 


### PR DESCRIPTION
Windows 10  creates an entry in Microsoft-Windows-Partition%4Diagnostic.evtx, EventID 1006, each time a USB device is connected to or disconnected from the system.  

USBs can have two serial number values and they are not always the same.  The serial number commonly referred to as iSerialNumber, is almost always unique and the value used in the WIndows registry to track USB activity.  The other serial number value, which I will refer to as the "alternate" serial number, can have duplicates or may be null.   The serial number value recorded in this event log is the non-unique one, the alternate serial number.   

When analyzing the physical USB device, different tools display one or the other serial number. There a few tools that display both.  You also use PowerShell to display both serial numbers.   In the absence of the physical devices, this log allows us to map between the non-unique serial number and the unique one stored in the registry by using the DiskID.  The DiskID is provided in this log and in the SYSTEM\CurrentControlSet\Enum\USBSTOR\ Device-Class\Device-SerialNumber\Device Parameters\Partmgr.  

