### PR TITLE
Update Application-Sophos-Alert_42.map

### DIFF
--- a/evtx/Maps/Application-Sophos-Alert_42.map
+++ b/evtx/Maps/Application-Sophos-Alert_42.map
@@ -2,6 +2,7 @@ Author: Mike Stewart mstew1968@gmail.com
 Description: Sophos System Protection
 EventId: 42
 Channel: Application
+Provider: "Sophos System Protection"
 Maps: 
   - 
     Property: PayloadData1


### PR DESCRIPTION
Added Provider so map wasn't parsing unrelated Application log events and associating them with Sophos activity