### PR TITLE
Fix regex in EventRecord to fix missing event data

### DIFF
--- a/evtx/EventRecord.cs
+++ b/evtx/EventRecord.cs
@@ -443,7 +443,7 @@ namespace evtx
 
             xmld.LoadXml(rawXml);
 
-            return Regex.Replace(xmld.Beautify(), " xmlns.+\"", "",
+            return Regex.Replace(xmld.Beautify(), " xmlns[^>]+", "",
                 RegexOptions.IgnoreCase | RegexOptions.Multiline);
         }
 


### PR DESCRIPTION
**What I changed**
Replace ` xmlns.+\"` with a more restricted regex ` xmlns[^>]+` to fix missing event data when " are found inside the event data. With the improved regex, we remove everything until the next '>' which I guess was intended.

**evtx version**
EvtxECmd version 0.6.5.0

**Describe the bug**
Parsing EVTX files using EvtxECmd removes important parts of the event log data, seen in scheduled task event logs.

When using the map https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4698.map against a security EVTX file which contains the event ID 4698, only the first part and the last part of the TaskContent is found in the output CSV.

I think it is due to a less restricted regex in: https://github.com/EricZimmerman/evtx/blob/98a655d8d5f21ad067640ccf1bf743eeac59a696/evtx/EventRecord.cs#L446

**To Reproduce**
Steps to reproduce the behavior:
1. Create a new scheduled task using e.g. `SCHTASKS /CREATE /SC DAILY /TN "MyTasks\Notepad task" /TR "C:\Windows\System32\notepad.exe" /ST 11:00`
1. Look into the security event logs (using filters such as "last hour" and event id 4698) and find the event for the newly created task
1. Run evtxecmd against the security log using `.\EvtxECmd.exe -d C:\evtx\ --csv C:\out\`
1. Important parts, like the command is missing in the output CSV

**Expected behavior**
The whole part of the TaskContent must be included in the CSV.

**Additional context**
The problem could be due to the xmlns-replacement which removes to much of the text: https://github.com/EricZimmerman/evtx/blob/98a655d8d5f21ad067640ccf1bf743eeac59a696/evtx/EventRecord.cs#L446

Everything between the xmlns and UserID is removed, among others the important command in scheduled task event logs. Therefore, I think it's due to the regex.

```
<Data Name="TaskContent"><?xml version="1.0" encoding="UTF-16"?> <Task version="1.2"
xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">....<Principal id="Author"> <UserId>...
```