### PR TITLE
Fix regex in EventRecord class to prevent the removal of relevant data

### DIFF
--- a/evtx/EventRecord.cs
+++ b/evtx/EventRecord.cs
@@ -443,7 +443,7 @@ namespace evtx
 
             xmld.LoadXml(rawXml);
 
-            return Regex.Replace(xmld.Beautify(), " xmlns.+\"", "",
+            return Regex.Replace(xmld.Beautify(), " xmlns.+\">", ">",
                 RegexOptions.IgnoreCase | RegexOptions.Multiline);
         }
 


### PR DESCRIPTION
See https://github.com/EricZimmerman/evtx/pull/122 as reference.

Fix a wrong regex-replacement in the EventRecord class which removed relevant data from event records. The fix makes that this regex-replacement only remove the xmlns tag inside the <Event> tag but leaves other found xmlns-tags as they are, e.g. found in TaskContent. I guess at the time of the regex replacement in the code we missed that TaskContent could contain that pattern too (scheduled task for example) which than removes important data (like task command).

**Fix**
Replace ` xmlns.+\"` regex with a more restricted regex `xmlns.+\">` and replace found string with the ">" to close the tag correctly again. This prevents the removal of important event data when " is found inside the event data itself, like TaskContent for scheduled task events.

**Tests**
I tested this new code against a lot of evtx files from a KAPE collection (195, all the standard evtx files from a production server) and everything's looks good, the only difference between the new and the old version is that the scheduled tasks events (updated, created, ...) have now the full TaskContent in the payload field in the CSV which was missing because of the wrong regex. Timeline Explorer shows the CSV correctly.

**Issue described in detail**
There are two xmlns values in some event log XML records (e.g task scheduler) and with the wrong currently used regex intended data is removed (first xmlns) but important data is removed too inside the TaskContent field which was never the intention. We removed the first xmlns correctly, but removed the second xmlns and much more too due to the used regex. We must prevent that.

```
<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
...
    <Data Name="TaskName">\MyTasks\Notepad task</Data>
    <Data Name="TaskContent">&amp;lt;?xml version="1.0" encoding="UTF-16"?&amp;gt;, &amp;lt;Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task"&amp;gt;,   &amp;lt;
```