### PR TITLE
Create SMBServer-Operational:1020, update Security:5145 and 5140

### DIFF
--- a/evtx/Maps/Microsoft-Windows-SMBServer-Operational_Microsoft-Windows-SMBServer_1020.map
+++ b/evtx/Maps/Microsoft-Windows-SMBServer-Operational_Microsoft-Windows-SMBServer_1020.map
@@ -1,0 +1,94 @@
+Author: Andrew Rathbun
+Description: File system operation has taken longer than expected
+EventId: 1020
+Channel: Microsoft-Windows-SMBServer/Operational
+Provider: Microsoft-Windows-SMBServer
+Maps:
+  -
+    Property: Username
+    PropertyValue: "%Username%"
+    Values:
+      -
+        Name: Username
+        Value: "/Event/UserData/EventData/Username"
+  -
+    Property: ExecutableInfo
+    PropertyValue: "FileName: %FileName%"
+    Values:
+      -
+        Name: FileName
+        Value: "/Event/UserData/EventData/FileName"
+  -
+    Property: PayloadData1
+    PropertyValue: "The threshold is %Threshold% milliseconds (15 seconds)"
+    Values:
+      -
+        Name: Threshold
+        Value: "/Event/UserData/EventData/Threshold"
+  -
+    Property: PayloadData2
+    PropertyValue: "The I/O operation took %Duration% milliseconds"
+    Values:
+      -
+        Name: Duration
+        Value: "/Event/UserData/EventData/Duration"
+  -
+    Property: PayloadData3
+    PropertyValue: "ClientName: %ClientName%"
+    Values:
+      -
+        Name: ClientName
+        Value: "/Event/UserData/EventData/ClientName"
+  -
+    Property: PayloadData4
+    PropertyValue: "ShareName: %ShareName%"
+    Values:
+      -
+        Name: ShareName
+        Value: "/Event/UserData/EventData/ShareName"
+
+# Documentation:
+# https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/troubleshoot-event-id-1020-warnings-file-server
+#
+# Example Event Data:
+#<Event>
+#  <System>
+#    <Provider Name="Microsoft-Windows-SMBServer" Guid="d48ce617-33a2-4bc3-a5c7-11aa4f29619e" />
+#    <EventID>1020</EventID>
+#    <Version>1</Version>
+#    <Level>3</Level>
+#    <Task>1020</Task>
+#    <Opcode>0</Opcode>
+#    <Keywords>0x2000000000000008</Keywords>
+#    <TimeCreated SystemTime="2021-01-15 21:48:56.679123" />
+#    <EventRecordID>72</EventRecordID>
+#    <Correlation />
+#    <Execution ProcessID="4" ThreadID="1234" />
+#    <Channel>Microsoft-Windows-SMBServer/Operational</Channel>
+#    <Computer>HOSTNAME.domain</Computer>
+#    <Security UserID="S-1-5-18" />
+#  </System>
+#  <UserData>
+#    <EventData>
+#      <Command>5</Command>
+#      <SessionGuid>4d0b74f0-14cc-0001-4f6e-114dcc14d701</SessionGuid>
+#      <SessionId>0x4C04C0200015</SessionId>
+#      <ConnectionGuid>4d0b74f0-14cc-0001-395e-679dcc14d701</ConnectionGuid>
+#      <UserNameLength>25</UserNameLength>
+#      <UserName>HOSTNAME\username</UserName>
+#      <ClientNameLength>12</ClientNameLength>
+#      <ClientName>\\10.1.10.20</ClientName>
+#      <ClientAddressLength>16</ClientAddressLength>
+#      <ClientAddress>02-00-C5-EC-0A-01-0A-1E-00-00-00-00-00-00-00-00</ClientAddress>
+#      <ShareNameLength>10</ShareNameLength>
+#      <ShareName>\\*\SYSVOL</ShareName>
+#      <FileNameLength>73</FileNameLength>
+#      <FileName>HOSTNAME.DOMAIN\POLICIES\{82B745A2-GG6D-4571-B214-0D8FCB672A5E}\GPT.INI</FileName>
+#      <Duration>46852</Duration>
+#      <Threshold>15000</Threshold>
+#      <CtlCode>9568402</CtlCode>
+#      <SubCode>0</SubCode>
+#      <TunneledControl>0</TunneledControl>
+#    </EventData>
+#  </UserData>
+#</Event>

--- a/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_5140.map
+++ b/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_5140.map
@@ -1,4 +1,4 @@
-Author: Eric Zimmerman saericzimmerman@gmail.com
+Author: Eric Zimmerman saericzimmerman@gmail.com and Andrew Rathbun
 Description: A network share object was accessed
 EventId: 5140
 Channel: Security
@@ -41,6 +41,61 @@ Maps:
       -
         Name: SubjectUserSid
         Value: "/Event/EventData/Data[@Name=\"SubjectUserSid\"]"
+  -
+    Property: PayloadData3
+    PropertyValue: "AccessList: %AccessList%"
+    Values:
+      -
+        Name: AccessList
+        Value: "/Event/EventData/Data[@Name=\"AccessList\"]"
+        Refine: "%%(.{4})"
+  -
+    Property: PayloadData4
+    PropertyValue: "AccessMask: %AccessMask%"
+    Values:
+      -
+        Name: AccessMask
+        Value: "/Event/EventData/Data[@Name=\"AccessMask\"]"
+
+Lookups:
+  -
+    Name: AccessList
+    Default: Unknown code
+    Values:
+      "%%4416": ReadData (or ListDirectory)
+      "%%4417": WriteData (or AddFile)
+      "%%4418": AppendData (or AddSubdirectory or CreatePipeInstance)
+      "%%4419": ReadEA (or Enumerate SubKeys)
+      "%%4420": WriteEA
+      "%%4421": Execute/Traverse
+      "%%4422": DeleteChild
+      "%%4423": ReadAttributes
+      "%%4424": WriteAttributes
+      "%%1537": DELETE
+      "%%1538": READ_CONTROL
+      "%%1539": WRITE_DAC
+      "%%1540": WRITE_OWNER
+      "%%1541": SYNCHRONIZE
+      "%%1542": ACCESS_SYS_SEC
+  -
+    Name: AccessMask
+    Default: Unknown code
+    Values:
+      "%%4416": ReadData (or ListDirectory)
+      "%%4417": WriteData (or AddFile)
+      "%%4418": AppendData (or AddSubdirectory or CreatePipeInstance)
+      "%%4419": ReadEA (or Enumerate SubKeys)
+      "%%4420": WriteEA
+      "%%4421": Execute/Traverse
+      "%%4422": DeleteChild
+      "%%4423": ReadAttributes
+      "%%4424": WriteAttributes
+      "%%1537": DELETE
+      "%%1538": READ_CONTROL
+      "%%1539": WRITE_DAC
+      "%%1540": WRITE_OWNER
+      "%%1541": SYNCHRONIZE
+      "%%1542": ACCESS_SYS_SEC
 
 # Documentation:
 # https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=5140

--- a/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_5145.map
+++ b/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_5145.map
@@ -43,21 +43,66 @@ Maps:
         Value: "/Event/EventData/Data[@Name=\"RelativeTargetName\"]"
   -
     Property: PayloadData3
-    PropertyValue: "AccessList: %AccessList% (AccessMask: %AccessMask%)"
+    PropertyValue: "AccessList: %AccessList%"
     Values:
       -
         Name: AccessList
         Value: "/Event/EventData/Data[@Name=\"AccessList\"]"
+        Refine: "%%(.{4})"
+  -
+    Property: PayloadData4
+    PropertyValue: "AccessMask: %AccessMask%"
+    Values:
       -
         Name: AccessMask
         Value: "/Event/EventData/Data[@Name=\"AccessMask\"]"
   -
-    Property: PayloadData4
+    Property: PayloadData5
     PropertyValue: "SID: %SubjectUserSid%"
     Values:
       -
         Name: SubjectUserSid
         Value: "/Event/EventData/Data[@Name=\"SubjectUserSid\"]"
+
+Lookups:
+  -
+    Name: AccessList
+    Default: Unknown code
+    Values:
+      "%%4416": ReadData (or ListDirectory)
+      "%%4417": WriteData (or AddFile)
+      "%%4418": AppendData (or AddSubdirectory or CreatePipeInstance)
+      "%%4419": ReadEA (or Enumerate SubKeys)
+      "%%4420": WriteEA
+      "%%4421": Execute/Traverse
+      "%%4422": DeleteChild
+      "%%4423": ReadAttributes
+      "%%4424": WriteAttributes
+      "%%1537": DELETE
+      "%%1538": READ_CONTROL
+      "%%1539": WRITE_DAC
+      "%%1540": WRITE_OWNER
+      "%%1541": SYNCHRONIZE
+      "%%1542": ACCESS_SYS_SEC
+  -
+    Name: AccessMask
+    Default: Unknown code
+    Values:
+      "%%4416": ReadData (or ListDirectory)
+      "%%4417": WriteData (or AddFile)
+      "%%4418": AppendData (or AddSubdirectory or CreatePipeInstance)
+      "%%4419": ReadEA (or Enumerate SubKeys)
+      "%%4420": WriteEA
+      "%%4421": Execute/Traverse
+      "%%4422": DeleteChild
+      "%%4423": ReadAttributes
+      "%%4424": WriteAttributes
+      "%%1537": DELETE
+      "%%1538": READ_CONTROL
+      "%%1539": WRITE_DAC
+      "%%1540": WRITE_OWNER
+      "%%1541": SYNCHRONIZE
+      "%%1542": ACCESS_SYS_SEC
 
 # Documentation:
 # https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=5145


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have ensured a Provider is listed for the new map(s) being submitted
- [x] I have ensured the filename(s) of any new map(s) being submitted follows the approved format, i.e. Channel-Name_Provider-Name_EventID.map (all spaces and special characters are replaced with a hyphen)
- [x] I have tested and validated the new map(s) work with my test data and achieve the desired output
- [x] I have provided example event data at the bottom of my map(s)
- [x] I have consulted the [guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
