### PR TITLE
Add SMB Server 551 Map, and fix lookup tables

### DIFF
--- a/evtx/Maps/Microsoft-Windows-SMBServer-Security_Microsoft-Windows-SMBServer_551.map
+++ b/evtx/Maps/Microsoft-Windows-SMBServer-Security_Microsoft-Windows-SMBServer_551.map
@@ -1,0 +1,114 @@
+Author: Andrew Rathbun
+Description: SMB session authentication failure
+EventId: 551
+Channel: "Microsoft-Windows-SMBServer/Security"
+Provider: "Microsoft-Windows-SMBServer"
+Maps:
+  -
+    Property: Username
+    PropertyValue: "%Username%"
+    Values:
+      -
+        Name: Username
+        Value: "/Event/UserData/EventData/Username"
+  -
+    Property: RemoteHost
+    PropertyValue: "%ClientName%"
+    Values:
+      -
+        Name: ClientName
+        Value: "/Event/UserData/EventData/ClientName"
+  -
+    Property: PayloadData1
+    PropertyValue: "Status: %Status%"
+    Values:
+      -
+        Name: Status
+        Value: "/Event/UserData/EventData/Status"
+  -
+    Property: PayloadData2
+    PropertyValue: "SessionGUID: %SessionGUID%"
+    Values:
+      -
+        Name: SessionGUID
+        Value: "/Event/UserData/EventData/SessionGUID"
+  -
+    Property: PayloadData3
+    PropertyValue: "ConnectionGUID: %ConnectionGUID%"
+    Values:
+      -
+        Name: ConnectionGUID
+        Value: "/Event/UserData/EventData/ConnectionGUID"
+  -
+    Property: PayloadData4
+    PropertyValue: "SessionId: %SessionId%"
+    Values:
+      -
+        Name: SessionId
+        Value: "/Event/UserData/EventData/SessionId"
+
+Lookups:
+  -
+    Name: Status
+    Default: Unknown code
+    Values:
+      0xC000005E: there are currently no logon servers available to service the logon request
+      0xC0000064: user name does not exist
+      0xC000006A: user name is correct but the password is wrong
+      0xC000006D: the cause is either a bad username or authentication information
+      0xC000006E: referenced user name and authentication information are valid, but some user account restriction has prevented successful authentication (such as time-of-day restrictions)
+      0xC000006F: user logon outside authorized hours
+      0xC0000070: user logon from unauthorized workstation
+      0xC0000071: user logon with expired password
+      0xC0000072: user logon to account disabled by administrator
+      0xC00000DC: indicates the Sam Server was in the wrong state to perform the desired operation
+      0xC000035C: the client's session has expired; therefore, the client MUST re-authenticate to continue accessing remote resources
+      0xC0000133: clocks between DC and other computer too far out of sync
+      0xC000015B: the user has not been granted the requested logon type (also called the logon right) at this machine
+      0xC000018C: the logon request failed because the trust relationship between the primary domain and the trusted domain failed
+      0xC0000192: an attempt was made to logon, but the Netlogon service was not started
+      0xC0000193: user logon with expired account
+      0xC0000224: user is required to change password at next logon
+      0xC0000225: evidently a bug in Windows and not a risk
+      0xC0000234: user is currently locked out
+      0x0: Status OK
+
+# Documentation:
+# https://github.com/defendthehoneypot/incidentresponse#smb-brute-force-login
+# https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/6ab6ca20-b404-41fd-b91a-2ed39e3762ea
+#
+# Example Event Data:
+#<Event>
+# <Event>
+#   <System>
+#     <Provider Name="Microsoft-Windows-SMBServer" Guid="d48ce617-33a2-4bc3-a5c7-11aa4f29619e" />
+#     <EventID>551</EventID>
+#     <Version>1</Version>
+#     <Level>2</Level>
+#     <Task>551</Task>
+#     <Opcode>0</Opcode>
+#     <Keywords>0x810000002200008</Keywords>
+#     <TimeCreated SystemTime="2020-01-14 00:37:09.4067902" />
+#     <EventRecordID>86585</EventRecordID>
+#     <Correlation />
+#     <Execution ProcessID="4" ThreadID="11788" />
+#     <Channel>Microsoft-Windows-SMBServer/Security</Channel>
+#     <Computer>HOSTNAME.domain</Computer>
+#     <Security UserID="S-1-5-18" />
+#   </System>
+#   <UserData>
+#     <EventData>
+#       <SessionGUID>30367936-3631-000a-5a2a-cabc9eb4d501</SessionGUID>
+#       <ConnectionGUID>30316796-3631-000a-592a-cfff9abcd501</ConnectionGUID>
+#       <Status>0xC000006D</Status>
+#       <TranslatedStatus>0xC000006D</TranslatedStatus>
+#       <ClientAddressLength>128</ClientAddressLength>
+#       <ClientAddress>02-00-F4-D5-0A-70-8C-8F-00-00-00-00-00-00-00-00-02-00-FF-FF-0A-70-8C-8F-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00</ClientAddress>
+#       <SessionId>0x17C3930000005</SessionId>
+#       <UserNameLength>0</UserNameLength>
+#       <UserName></UserName>
+#       <ClientNameLength>16</ClientNameLength>
+#       <ClientName>\\10.123.123.123</ClientName>
+#     </EventData>
+#   </UserData>
+# </Event>

--- a/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4625.map
+++ b/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4625.map
@@ -61,23 +61,23 @@ Lookups:
     Name: SubStatus
     Default: Unknown code
     Values:
-      0XC000005E: there are currently no logon servers available to service the logon request
+      0xC000005E: there are currently no logon servers available to service the logon request
       0xC0000064: user name does not exist
       0xC000006A: user name is correct but the password is wrong
-      0XC000006D: the cause is either a bad username or authentication information
-      0XC000006E: referenced user name and authentication information are valid, but some user account restriction has prevented successful authentication (such as time-of-day restrictions)
+      0xC000006D: the cause is either a bad username or authentication information
+      0xC000006E: referenced user name and authentication information are valid, but some user account restriction has prevented successful authentication (such as time-of-day restrictions)
       0xC000006F: user logon outside authorized hours
       0xC0000070: user logon from unauthorized workstation
       0xC0000071: user logon with expired password
       0xC0000072: user logon to account disabled by administrator
-      0XC00000DC: indicates the Sam Server was in the wrong state to perform the desired operation.
-      0XC0000133: clocks between DC and other computer too far out of sync
-      0XC000015B: the user has not been granted the requested logon type (also called the logon right) at this machine
-      0XC000018C: the logon request failed because the trust relationship between the primary domain and the trusted domain failed.
-      0XC0000192: an attempt was made to logon, but the Netlogon service was not started.
+      0xC00000DC: indicates the Sam Server was in the wrong state to perform the desired operation.
+      0xC0000133: clocks between DC and other computer too far out of sync
+      0xC000015B: the user has not been granted the requested logon type (also called the logon right) at this machine
+      0xC000018C: the logon request failed because the trust relationship between the primary domain and the trusted domain failed.
+      0xC0000192: an attempt was made to logon, but the Netlogon service was not started.
       0xC0000193: user logon with expired account
-      0XC0000224: user is required to change password at next logon
-      0XC0000225: evidently a bug in Windows and not a risk
+      0xC0000224: user is required to change password at next logon
+      0xC0000225: evidently a bug in Windows and not a risk
       0xC0000234: user is currently locked out
       0x0: Status OK
 

--- a/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4625.map
+++ b/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4625.map
@@ -71,7 +71,6 @@ Lookups:
       0xC0000071: user logon with expired password
       0xC0000072: user logon to account disabled by administrator
       0xC00000DC: indicates the Sam Server was in the wrong state to perform the desired operation
-      0xC000035C: the client's session has expired; therefore, the client MUST re-authenticate to continue accessing remote resources
       0xC0000133: clocks between DC and other computer too far out of sync
       0xC000015B: the user has not been granted the requested logon type (also called the logon right) at this machine
       0xC000018C: the logon request failed because the trust relationship between the primary domain and the trusted domain failed

--- a/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4625.map
+++ b/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4625.map
@@ -70,10 +70,11 @@ Lookups:
       0xC0000070: user logon from unauthorized workstation
       0xC0000071: user logon with expired password
       0xC0000072: user logon to account disabled by administrator
-      0xC00000DC: indicates the Sam Server was in the wrong state to perform the desired operation.
+      0xC00000DC: indicates the Sam Server was in the wrong state to perform the desired operation
+      0xC000035C: the client's session has expired; therefore, the client MUST re-authenticate to continue accessing remote resources
       0xC0000133: clocks between DC and other computer too far out of sync
       0xC000015B: the user has not been granted the requested logon type (also called the logon right) at this machine
-      0xC000018C: the logon request failed because the trust relationship between the primary domain and the trusted domain failed.
+      0xC000018C: the logon request failed because the trust relationship between the primary domain and the trusted domain failed
       0xC0000192: an attempt was made to logon, but the Netlogon service was not started.
       0xC0000193: user logon with expired account
       0xC0000224: user is required to change password at next logon


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have ensured a Provider is listed for the new Map(s) being submitted
- [ ] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. Channel-Name_Provider-Name_EventID.map (all spaces and special characters are replaced with a hyphen)
- [ ] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [ ] I have provided example event data at the bottom of my Map(s)
- [ ] I have consulted the [guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
