### PR TITLE
Use standard .NET libraries instead of windows only libraries

### DIFF
--- a/EvtxECmd/EvtxECmd.csproj
+++ b/EvtxECmd/EvtxECmd.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyTitle>EvtxECmd</AssemblyTitle>
     <Company>Eric R. Zimmerman</Company>
@@ -18,6 +18,7 @@
     <ApplicationIcon>IDCard.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="SharpZipLib" Version="1.3.2" />
     <PackageReference Include="System.IO.Compression" Version="4.*" />
     <PackageReference Include="System.Threading" Version="4.*" />
     <PackageReference Include="System.Threading.Tasks" Version="4.*" />
@@ -44,18 +45,18 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AlphaFS" Version="2.2.6" />
-    <PackageReference Include="Costura.Fody" Version="5.1.0">
+    <PackageReference Include="Costura.Fody" Version="5.3.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="CsvHelper" Version="26.1.0" />
+    <PackageReference Include="CsvHelper" Version="27.1.0" />
     <PackageReference Include="Exceptionless" Version="4.6.2" />
     <PackageReference Include="FluentCommandLineParser" Version="1.5.0.20-commands" />
     <PackageReference Include="Fody" Version="6.5.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NLog" Version="4.7.9" />
-    <PackageReference Include="ServiceStack.Text" Version="5.10.4" />
+    <PackageReference Include="NLog" Version="4.7.10" />
+    <PackageReference Include="ServiceStack.Text" Version="5.11.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />

--- a/EvtxECmd/EvtxECmd.csproj
+++ b/EvtxECmd/EvtxECmd.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AlphaFS" Version="2.2.6" />
-    <PackageReference Include="Costura.Fody" Version="5.3.0">
+    <PackageReference Include="Costura.Fody" Version="5.2.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="CsvHelper" Version="27.1.0" />

--- a/evtx.Test/evtx.Test.csproj
+++ b/evtx.Test/evtx.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>net46;net5.0</TargetFrameworks>
     <AssemblyTitle>evtx.Test</AssemblyTitle>
     <Product>evtx.Test</Product>
     <Copyright>Copyright ©  2019</Copyright>
@@ -12,16 +12,11 @@
     <PackageReference Include="System.Net.Http" Version="4.*" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Transactions" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\evtx\evtx.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NFluent" Version="2.7.1" />
-    <PackageReference Include="NLog" Version="4.7.9" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="NFluent" Version="2.7.2" />
+    <PackageReference Include="NLog" Version="4.7.10" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
   </ItemGroup>
 </Project>

--- a/evtx/EventLog.cs
+++ b/evtx/EventLog.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using Alphaleonis.Win32.Filesystem;
 using FluentValidation.Results;
 using Force.Crc32;
 using NLog;
@@ -11,9 +10,6 @@ using ServiceStack;
 using ServiceStack.Text;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
-using Directory = Alphaleonis.Win32.Filesystem.Directory;
-using File = Alphaleonis.Win32.Filesystem.File;
-using Path = Alphaleonis.Win32.Filesystem.Path;
 
 //TODO rename project to EventLog?
 namespace evtx
@@ -113,20 +109,8 @@ namespace evtx
         {
             EventLogMaps = new Dictionary<string, EventLogMap>();
 
-            var f = new DirectoryEnumerationFilters();
-            f.InclusionFilter = fsei => fsei.Extension.ToUpperInvariant() == ".MAP";
-
-            f.RecursionFilter = null; //entryInfo => !entryInfo.IsMountPoint && !entryInfo.IsSymbolicLink;
-
-            f.ErrorFilter = (errorCode, errorMessage, pathProcessed) => true;
-
-            var dirEnumOptions =
-                DirectoryEnumerationOptions.Files |
-                DirectoryEnumerationOptions.SkipReparsePoints | DirectoryEnumerationOptions.ContinueOnException |
-                DirectoryEnumerationOptions.BasicSearch;
-
             var mapFiles =
-                Directory.EnumerateFileSystemEntries(mapPath, dirEnumOptions, f).ToList();
+                Directory.EnumerateFileSystemEntries(mapPath, "*.MAP").ToList();
 
             var l = LogManager.GetLogger("LoadMaps");
 

--- a/evtx/EventLog.cs
+++ b/evtx/EventLog.cs
@@ -110,7 +110,7 @@ namespace evtx
             EventLogMaps = new Dictionary<string, EventLogMap>();
 
             var mapFiles =
-                Directory.EnumerateFileSystemEntries(mapPath, "*.MAP").ToList();
+                Directory.EnumerateFileSystemEntries(mapPath, "*.map").ToList();
 
             var l = LogManager.GetLogger("LoadMaps");
 

--- a/evtx/evtx.csproj
+++ b/evtx/evtx.csproj
@@ -8,9 +8,9 @@
     <Copyright>Copyright ©  2021</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <AssemblyVersion>1.0.0.1</AssemblyVersion>
-    <FileVersion>1.0.0.1</FileVersion>
-    <Version>1.0.0.1</Version>
+    <AssemblyVersion>1.0.1</AssemblyVersion>
+    <FileVersion>1.0.1</FileVersion>
+    <Version>1.0.1</Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,17 +22,10 @@
     <PackageReference Include="System.Net.Http" Version="4.*" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Transactions" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="AlphaFS" Version="2.2.6" />
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
     <PackageReference Include="FluentValidation" Version="8.6.1" />
     <PackageReference Include="NLog" Version="4.7.9" />
     <PackageReference Include="ServiceStack.Text" Version="5.10.4" />
-    <PackageReference Include="SharpZipLib" Version="1.3.1" />
     <PackageReference Include="System.Xml.XPath" Version="4.3.0" />
     <PackageReference Include="YamlDotNet" Version="11.0.1" />
   </ItemGroup>


### PR DESCRIPTION
## Description

Use standard .NET libraries instead of windows-only ones, so the evtx lib can be used in linux (with .NET 5)
**Note:** The tests are not usable as they need files that aren't included, so I wasn't able to properly test this.