### PR TITLE
Remove trailing spaces

### DIFF
--- a/evtx/Maps/Microsoft-Windows-SMBServer-Operational_Microsoft-Windows-SMBServer_1016.map
+++ b/evtx/Maps/Microsoft-Windows-SMBServer-Operational_Microsoft-Windows-SMBServer_1016.map
@@ -31,7 +31,7 @@ Maps:
     Values:
       -
         Name: ShareName
-        Value: "/Event/UserData/EventData/ShareName"  
+        Value: "/Event/UserData/EventData/ShareName"
   -
     Property: PayloadData2
     PropertyValue: "Status: %Status%"
@@ -59,33 +59,33 @@ Lookups:
     Name: Status
     Default: Unknown code
     Values:
-      0x00000000: STATUS_SUCCESS - The client request is successful.                                                                                                                                                                                                                                     
-      0x00010002: STATUS_INVALID_SMB - An invalid SMB client request is received by the server.                                                                                                                                                                                                          
-      0x00050002: STATUS_SMB_BAD_TID - The client request received by the server contains an invalid TID value.                                                                                                                                                                                          
-      0x00160002: STATUS_SMB_BAD_COMMAND - The client request received by the server contains an unknown SMB command code.                                                                                                                                                                               
-      0x005B0002: STATUS_SMB_BAD_UID - The client request to the server contains an invalid UID value.                                                                                                                                                                                                   
-      0x00FB0002: STATUS_SMB_USE_STANDARD - The client request received by the server is for a non-standard SMB operation (for example, an SMB_COM_READ_MPX request on a non-disk share). The client SHOULD send another request with a different SMB command to perform this operation.                 
-      0x80000005: STATUS_BUFFER_OVERFLOW - The data was too large to fit into the specified buffer.                                                                                                                                                                                                      
-      0x80000006: STATUS_NO_MORE_FILES - No more files were found that match the file specification.                                                                                                                                                                                                     
-      0x8000002D: STATUS_STOPPED_ON_SYMLINK - The create operation stopped after reaching a symbolic link.                                                                                                                                                                                               
-      0xC0000002: STATUS_NOT_IMPLEMENTED - The requested operation is not implemented.                                                                                                                                                                                                                   
-      0xC000000D: STATUS_INVALID_PARAMETER - The parameter specified in the request is not valid.                                                                                                                                                                                                        
-      0xC000000E: STATUS_NO_SUCH_DEVICE - A device that does not exist was specified.                                                                                                                                                                                                                    
-      0xC0000010: STATUS_INVALID_DEVICE_REQUEST - The specified request is not a valid operation for the target device.                                                                                                                                                                                  
+      0x00000000: STATUS_SUCCESS - The client request is successful.
+      0x00010002: STATUS_INVALID_SMB - An invalid SMB client request is received by the server.
+      0x00050002: STATUS_SMB_BAD_TID - The client request received by the server contains an invalid TID value.
+      0x00160002: STATUS_SMB_BAD_COMMAND - The client request received by the server contains an unknown SMB command code.
+      0x005B0002: STATUS_SMB_BAD_UID - The client request to the server contains an invalid UID value.
+      0x00FB0002: STATUS_SMB_USE_STANDARD - The client request received by the server is for a non-standard SMB operation (for example, an SMB_COM_READ_MPX request on a non-disk share). The client SHOULD send another request with a different SMB command to perform this operation.
+      0x80000005: STATUS_BUFFER_OVERFLOW - The data was too large to fit into the specified buffer.
+      0x80000006: STATUS_NO_MORE_FILES - No more files were found that match the file specification.
+      0x8000002D: STATUS_STOPPED_ON_SYMLINK - The create operation stopped after reaching a symbolic link.
+      0xC0000002: STATUS_NOT_IMPLEMENTED - The requested operation is not implemented.
+      0xC000000D: STATUS_INVALID_PARAMETER - The parameter specified in the request is not valid.
+      0xC000000E: STATUS_NO_SUCH_DEVICE - A device that does not exist was specified.
+      0xC0000010: STATUS_INVALID_DEVICE_REQUEST - The specified request is not a valid operation for the target device.
       0xC0000016: STATUS_MORE_PROCESSING_REQUIRED - If extended security has been negotiated, then this error code can be returned in the SMB_COM_SESSION_SETUP_ANDX response from the server to indicate that additional authentication information is to be exchanged. See section 2.2.4.6 for details.
-      0xC0000022: STATUS_ACCESS_DENIED - The client did not have the required permission needed for the operation.                                                                                                                                                                                       
-      0xC0000023: STATUS_BUFFER_TOO_SMALL - The buffer is too small to contain the entry. No information has been written to the buffer.                                                                                                                                                                 
-      0xC0000034: STATUS_OBJECT_NAME_NOT_FOUND - The object name is not found.                                                                                                                                                                                                                           
-      0xC0000035: STATUS_OBJECT_NAME_COLLISION - The object name already exists.                                                                                                                                                                                                                         
-      0xC000003A: STATUS_OBJECT_PATH_NOT_FOUND - The path to the directory specified was not found. This error is also returned on a create request if the operation requires the creation of more than one new directory level for the path specified.                                                  
-      0xC00000A5: STATUS_BAD_IMPERSONATION_LEVEL - A specified impersonation level is invalid. This error is also used to indicate that a required impersonation level was not provided.                                                                                                                 
-      0xC00000B5: STATUS_IO_TIMEOUT - The specified I/O operation was not completed before the time-out period expired.                                                                                                                                                                                  
-      0xC00000BA: STATUS_FILE_IS_A_DIRECTORY - The file that was specified as a target is a directory and the caller specified that it could be anything but a directory.                                                                                                                                
-      0xC00000BB: STATUS_NOT_SUPPORTED - The client request is not supported.                                                                                                                                                                                                                            
-      0xC00000C9: STATUS_NETWORK_NAME_DELETED - The network name specified by the client has been deleted on the server. This error is returned if the client specifies an incorrect TID or the share on the server represented by the TID was deleted.                                                  
-      0xC0000203: STATUS_USER_SESSION_DELETED - The user session specified by the client has been deleted on the server. This error is returned by the server if the client sends an incorrect UID.                                                                                                      
-      0xC000035C: STATUS_NETWORK_SESSION_EXPIRED - The client's session has expired; therefore, the client MUST re-authenticate to continue accessing remote resources.                                                                                                                                  
-      0xC000205A: STATUS_SMB_TOO_MANY_UIDS - The client has requested too many UID values from the server or the client already has an SMB session setup with this UID value.                                                                                                                            
+      0xC0000022: STATUS_ACCESS_DENIED - The client did not have the required permission needed for the operation.
+      0xC0000023: STATUS_BUFFER_TOO_SMALL - The buffer is too small to contain the entry. No information has been written to the buffer.
+      0xC0000034: STATUS_OBJECT_NAME_NOT_FOUND - The object name is not found.
+      0xC0000035: STATUS_OBJECT_NAME_COLLISION - The object name already exists.
+      0xC000003A: STATUS_OBJECT_PATH_NOT_FOUND - The path to the directory specified was not found. This error is also returned on a create request if the operation requires the creation of more than one new directory level for the path specified.
+      0xC00000A5: STATUS_BAD_IMPERSONATION_LEVEL - A specified impersonation level is invalid. This error is also used to indicate that a required impersonation level was not provided.
+      0xC00000B5: STATUS_IO_TIMEOUT - The specified I/O operation was not completed before the time-out period expired.
+      0xC00000BA: STATUS_FILE_IS_A_DIRECTORY - The file that was specified as a target is a directory and the caller specified that it could be anything but a directory.
+      0xC00000BB: STATUS_NOT_SUPPORTED - The client request is not supported.
+      0xC00000C9: STATUS_NETWORK_NAME_DELETED - The network name specified by the client has been deleted on the server. This error is returned if the client specifies an incorrect TID or the share on the server represented by the TID was deleted.
+      0xC0000203: STATUS_USER_SESSION_DELETED - The user session specified by the client has been deleted on the server. This error is returned by the server if the client sends an incorrect UID.
+      0xC000035C: STATUS_NETWORK_SESSION_EXPIRED - The client's session has expired; therefore, the client MUST re-authenticate to continue accessing remote resources.
+      0xC000205A: STATUS_SMB_TOO_MANY_UIDS - The client has requested too many UID values from the server or the client already has an SMB session setup with this UID value.
 
 # Documentation:
 # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb/6ab6ca20-b404-41fd-b91a-2ed39e3762ea


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have ensured a Provider is listed for the new Map(s) being submitted
- [ ] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. Channel-Name_Provider-Name_EventID.map (all spaces and special characters are replaced with a hyphen)
- [ ] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [ ] I have provided example event data at the bottom of my Map(s)
- [ ] I have consulted the [guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
