### PR TITLE
Update PrintService_307.map

### DIFF
--- a/evtx/Maps/Microsoft-Windows-PrintService-Operational_Microsoft-Windows-PrintService_307.map
+++ b/evtx/Maps/Microsoft-Windows-PrintService-Operational_Microsoft-Windows-PrintService_307.map
@@ -1,4 +1,4 @@
-Author: Barrie Hill barrie0482@gmail.com
+Author: Barrie Hill barrie0482@gmail.com/esecrpm
 Description: Printing a document
 EventId: 307
 Channel: "Microsoft-Windows-PrintService/Operational"
@@ -31,7 +31,7 @@ Maps:
     Values:
       -
         Name: DocumentName
-        Value: "/Event/UserData/DocumentPrinted/Param6"
+        Value: "/Event/UserData/DocumentPrinted/Param2"
   -
     Property: PayloadData5
     PropertyValue: "Size in Bytes: %Bytes%"
@@ -48,14 +48,17 @@ Maps:
         Value: "/Event/UserData/DocumentPrinted/Param8"
 
 # Documentation:
-# https://eventlogxp.com/blog/how-to-track-printer-usage-with-event-logs/
+# https://eventlogxp.com/blog/how-to-track-printer-usage-with-event-logs
+#
+# The document name is not recorded in the event record until enabled via Group Policy
+# https://social.technet.microsoft.com/Forums/ie/en-US/12e60098-1f46-4c6e-8b10-9c816dadb2b2/kb-fix-for-print-document-name-in-event-logs-on-server-2012-and-server-2012r2?forum=winserverprint
 #
 # Param1 --> Document Number
-# Param2 --> Event Operation
+# Param2 --> Document Name
 # Param3 --> PrintUser
 # Param4 --> PrintHost
 # Param5 --> Printer Name
-# Param6 --> Document Name
+# Param6 --> Printer Port
 # Param7 --> Document size in Bytes
 # Param8 --> Number of Pages
 #


### PR DESCRIPTION
Update Microsoft-Windows-PrintService-Operational_Microsoft-Windows-PrintService_307.map to correct the parameter used (Param2) for Document Name.  This parameter contains the default value "Print Document" until the ShowJobTitleInEvent setting is enabled in Group Policy.

## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [x] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [x] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [x] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [x] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
