### PR TITLE
Create System_TermDD_56.map

### DIFF
--- a/evtx/Maps/System_TermDD_56.map
+++ b/evtx/Maps/System_TermDD_56.map
@@ -27,12 +27,12 @@ Maps:
 #    <TimeCreated SystemTime="2021-06-01T12:13:20.176180300Z" /> 
 #    <EventRecordID>163487</EventRecordID> 
 #    <Channel>System</Channel> 
-#    <Computer>TONJC-CM.TON-Judicial.local</Computer> 
+#    <Computer></Computer> 
 #    <Security /> 
 #    </System>
 #    <EventData>
 #     <Data>\Device\Termdd</Data> 
-#     <Data>167.248.133.39</Data> 
-#     <Binary>009F040002002C000000000038000AC00000000038000AC00000000000000000000000000000000008030980</Binary> 
+#     <Data>IP ADDRESS</Data> 
+#     <Binary>STATUS CODE IN BINARY</Binary> 
 #    </EventData>
 #  </Event>

--- a/evtx/Maps/System_TermDD_56.map
+++ b/evtx/Maps/System_TermDD_56.map
@@ -4,35 +4,35 @@ EventId: 56
 Channel: System
 Provider: TermDD
 Maps:
-  -
-    Property: PayloadData1
-    PropertyValue: "Data: %Data%"
-    Values:
-      -
-        Name: Data
-        Value: "/Event/EventData/Data"
+-
+Property: PayloadData1
+PropertyValue: "Data: %Data%"
+Values:
+-
+Name: Data
+Value: "/Event/EventData/Data"
 
 # Documentation:
 # https://techcommunity.microsoft.com/t5/ask-the-performance-team/the-curious-case-of-event-id-56-with-source-termdd/ba-p/374553
-# Remember you will need to decode the binary (the documentation above explains it) to actually figure out WHAT it was trying to do. 
-# However, these are basically "frozen" RDP connections. 
+# Remember you will need to decode the binary (the documentation above explains it) to actually figure out WHAT it was trying to do.
+# However, these are basically "frozen" RDP connections.
 
 #- <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
 #   <System>
-#    <Provider Name="TermDD" /> 
-#    <EventID Qualifiers="49162">56</EventID> 
-#    <Level>2</Level> 
-#    <Task>0</Task> 
-#    <Keywords>0x80000000000000</Keywords> 
-#    <TimeCreated SystemTime="2021-06-01T12:13:20.176180300Z" /> 
-#    <EventRecordID>163487</EventRecordID> 
-#    <Channel>System</Channel> 
-#    <Computer></Computer> 
-#    <Security /> 
+#    <Provider Name="TermDD" />
+#    <EventID Qualifiers="49162">56</EventID>
+#    <Level>2</Level>
+#    <Task>0</Task>
+#    <Keywords>0x80000000000000</Keywords>
+#    <TimeCreated SystemTime="2021-06-01T12:13:20.176180300Z" />
+#    <EventRecordID>163487</EventRecordID>
+#    <Channel>System</Channel>
+#    <Computer></Computer>
+#    <Security />
 #    </System>
 #    <EventData>
-#     <Data>\Device\Termdd</Data> 
-#     <Data>IP ADDRESS</Data> 
-#     <Binary>STATUS CODE IN BINARY</Binary> 
+#     <Data>\Device\Termdd</Data>
+#     <Data>IP ADDRESS</Data>
+#     <Binary>STATUS CODE IN BINARY</Binary>
 #    </EventData>
 #  </Event>

--- a/evtx/Maps/System_TermDD_56.map
+++ b/evtx/Maps/System_TermDD_56.map
@@ -4,11 +4,11 @@ EventId: 56
 Channel: System
 Provider: TermDD
 Maps:
--
+  -
 Property: PayloadData1
 PropertyValue: "Data: %Data%"
 Values:
--
+  -
 Name: Data
 Value: "/Event/EventData/Data"
 
@@ -17,7 +17,7 @@ Value: "/Event/EventData/Data"
 # Remember you will need to decode the binary (the documentation above explains it) to actually figure out WHAT it was trying to do.
 # However, these are basically "frozen" RDP connections.
 
-#- <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+# <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
 #   <System>
 #    <Provider Name="TermDD" />
 #    <EventID Qualifiers="49162">56</EventID>

--- a/evtx/Maps/System_TermDD_56.map
+++ b/evtx/Maps/System_TermDD_56.map
@@ -1,0 +1,38 @@
+Author: Tony Knutson
+Description: TermDD
+EventId: 56
+Channel: System
+Provider: TermDD
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "Data: %Data%"
+    Values:
+      -
+        Name: Data
+        Value: "/Event/EventData/Data"
+
+# Documentation:
+# https://techcommunity.microsoft.com/t5/ask-the-performance-team/the-curious-case-of-event-id-56-with-source-termdd/ba-p/374553
+# Remember you will need to decode the binary (the documentation above explains it) to actually figure out WHAT it was trying to do. 
+# However, these are basically "frozen" RDP connections. 
+
+#- <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+#   <System>
+#    <Provider Name="TermDD" /> 
+#    <EventID Qualifiers="49162">56</EventID> 
+#    <Level>2</Level> 
+#    <Task>0</Task> 
+#    <Keywords>0x80000000000000</Keywords> 
+#    <TimeCreated SystemTime="2021-06-01T12:13:20.176180300Z" /> 
+#    <EventRecordID>163487</EventRecordID> 
+#    <Channel>System</Channel> 
+#    <Computer>TONJC-CM.TON-Judicial.local</Computer> 
+#    <Security /> 
+#    </System>
+#    <EventData>
+#     <Data>\Device\Termdd</Data> 
+#     <Data>167.248.133.39</Data> 
+#     <Binary>009F040002002C000000000038000AC00000000038000AC00000000000000000000000000000000008030980</Binary> 
+#    </EventData>
+#  </Event>

--- a/evtx/Maps/System_TermDD_56.map
+++ b/evtx/Maps/System_TermDD_56.map
@@ -5,12 +5,12 @@ Channel: System
 Provider: TermDD
 Maps:
   -
-Property: PayloadData1
-PropertyValue: "Data: %Data%"
-Values:
-  -
-Name: Data
-Value: "/Event/EventData/Data"
+    Property: PayloadData1
+    PropertyValue: "Data: %Data%"
+    Values:
+      -
+        Name: Data
+        Value: "/Event/EventData/Data"
 
 # Documentation:
 # https://techcommunity.microsoft.com/t5/ask-the-performance-team/the-curious-case-of-event-id-56-with-source-termdd/ba-p/374553


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [x] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [x] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [x] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [x] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
