### PR TITLE
New Cisco AnyConnect/DHCP, updated PrintService maps

### DIFF
--- a/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2039.map
+++ b/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2039.map
@@ -1,0 +1,36 @@
+Author: esecrpm
+Description: Cisco AnyConnect VPN Connection Established
+EventId: 2039
+Channel: "Cisco AnyConnect Secure Mobility Client"
+Provider: acvpnagent
+Maps: 
+  - 
+    Property: PayloadData1
+    PropertyValue: "%PayloadData1%"
+    Values: 
+      - 
+        Name: PayloadData1
+        Value: "/Event/EventData/Data"
+        Refine: "(?<=, )[^,\\d]+(?=,)"
+
+# Valid properties include:
+# 
+# PayloadData1
+
+# <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+#   <System>
+#     <Provider Name="acvpnagent" /> 
+#     <EventID Qualifiers="25600">2039</EventID> 
+#     <Level>4</Level> 
+#     <Task>0</Task> 
+#     <Keywords>0x80000000000000</Keywords> 
+#     <TimeCreated SystemTime="2020-10-08T15:58:49.2901037Z" /> 
+#     <EventRecordID>7188</EventRecordID> 
+#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel> 
+#     <Computer>foobar</Computer> 
+#     <Security /> 
+#   </System>
+#   <EventData>
+#     <Data>The VPN connection has been established and can now pass data.</Data> 
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2039.map
+++ b/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2039.map
@@ -1,4 +1,3 @@
-
 Author: esecrpm
 Description: Cisco AnyConnect VPN Connection Established
 EventId: 2039

--- a/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2039.map
+++ b/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2039.map
@@ -1,36 +1,36 @@
+
 Author: esecrpm
 Description: Cisco AnyConnect VPN Connection Established
 EventId: 2039
 Channel: "Cisco AnyConnect Secure Mobility Client"
 Provider: acvpnagent
-Maps: 
-  - 
+Maps:
+  -
     Property: PayloadData1
     PropertyValue: "%PayloadData1%"
-    Values: 
-      - 
+    Values:
+      -
         Name: PayloadData1
         Value: "/Event/EventData/Data"
         Refine: "(?<=, )[^,\\d]+(?=,)"
 
-# Valid properties include:
-# 
-# PayloadData1
-
+# Documentation
+# N/A
+#
 # <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
 #   <System>
-#     <Provider Name="acvpnagent" /> 
-#     <EventID Qualifiers="25600">2039</EventID> 
-#     <Level>4</Level> 
-#     <Task>0</Task> 
-#     <Keywords>0x80000000000000</Keywords> 
-#     <TimeCreated SystemTime="2020-10-08T15:58:49.2901037Z" /> 
-#     <EventRecordID>7188</EventRecordID> 
-#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel> 
-#     <Computer>foobar</Computer> 
-#     <Security /> 
+#     <Provider Name="acvpnagent" />
+#     <EventID Qualifiers="25600">2039</EventID>
+#     <Level>4</Level>
+#     <Task>0</Task>
+#     <Keywords>0x80000000000000</Keywords>
+#     <TimeCreated SystemTime="2020-10-08T15:58:49.2901037Z" />
+#     <EventRecordID>7188</EventRecordID>
+#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel>
+#     <Computer>foobar</Computer>
+#     <Security />
 #   </System>
 #   <EventData>
-#     <Data>The VPN connection has been established and can now pass data.</Data> 
+#     <Data>The VPN connection has been established and can now pass data.</Data>
 #   </EventData>
 # </Event>

--- a/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2072.map
+++ b/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2072.map
@@ -3,34 +3,33 @@ Description: Cisco AnyConnect VPN Active Interface Addresses
 EventId: 2072
 Channel: "Cisco AnyConnect Secure Mobility Client"
 Provider: acvpnagent
-Maps: 
-  - 
+Maps:
+  -
     Property: PayloadData1
     PropertyValue: "%PayloadData1%"
-    Values: 
-      - 
+    Values:
+      -
         Name: PayloadData1
         Value: "/Event/EventData/Data"
         Refine: "(?<=, )[^,\\d]+(?=,)"
 
-# Valid properties include:
-# 
-# PayloadData1
-
+# Documentation
+# N/A
+#
 # <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
 #   <System>
-#     <Provider Name="acvpnagent" /> 
-#     <EventID Qualifiers="25600">2072</EventID> 
-#     <Level>4</Level> 
-#     <Task>0</Task> 
-#     <Keywords>0x80000000000000</Keywords> 
-#     <TimeCreated SystemTime="2020-10-09T11:59:43.2405786Z" /> 
-#     <EventRecordID>7519</EventRecordID> 
-#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel> 
-#     <Computer>foobar</Computer> 
-#     <Security /> 
+#     <Provider Name="acvpnagent" />
+#     <EventID Qualifiers="25600">2072</EventID>
+#     <Level>4</Level>
+#     <Task>0</Task>
+#     <Keywords>0x80000000000000</Keywords>
+#     <TimeCreated SystemTime="2020-10-09T11:59:43.2405786Z" />
+#     <EventRecordID>7519</EventRecordID>
+#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel>
+#     <Computer>foobar</Computer>
+#     <Security />
 #   </System>
 #   <EventData>
-#     <Data>IP addresses from active interfaces: Ethernet: 10.1.1.1, FE80::1234</Data> 
+#     <Data>IP addresses from active interfaces: Ethernet: 10.1.1.1, FE80::1234</Data>
 #   </EventData>
 # </Event>

--- a/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2072.map
+++ b/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2072.map
@@ -1,0 +1,36 @@
+Author: esecrpm
+Description: Cisco AnyConnect VPN Active Interface Addresses
+EventId: 2072
+Channel: "Cisco AnyConnect Secure Mobility Client"
+Provider: acvpnagent
+Maps: 
+  - 
+    Property: PayloadData1
+    PropertyValue: "%PayloadData1%"
+    Values: 
+      - 
+        Name: PayloadData1
+        Value: "/Event/EventData/Data"
+        Refine: "(?<=, )[^,\\d]+(?=,)"
+
+# Valid properties include:
+# 
+# PayloadData1
+
+# <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+#   <System>
+#     <Provider Name="acvpnagent" /> 
+#     <EventID Qualifiers="25600">2072</EventID> 
+#     <Level>4</Level> 
+#     <Task>0</Task> 
+#     <Keywords>0x80000000000000</Keywords> 
+#     <TimeCreated SystemTime="2020-10-09T11:59:43.2405786Z" /> 
+#     <EventRecordID>7519</EventRecordID> 
+#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel> 
+#     <Computer>foobar</Computer> 
+#     <Security /> 
+#   </System>
+#   <EventData>
+#     <Data>IP addresses from active interfaces: Ethernet: 10.1.1.1, FE80::1234</Data> 
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2079.map
+++ b/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2079.map
@@ -1,0 +1,36 @@
+Author: esecrpm
+Description: Cisco AnyConnect VPN Host Configuration
+EventId: 2079
+Channel: "Cisco AnyConnect Secure Mobility Client"
+Provider: acvpnagent
+Maps: 
+  - 
+    Property: PayloadData1
+    PropertyValue: "%PayloadData1%"
+    Values: 
+      - 
+        Name: PayloadData1
+        Value: "/Event/EventData/Data"
+        Refine: "(?<=, )[^,\\d]+(?=,)"
+
+# Valid properties include:
+# 
+# PayloadData1
+
+# <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+#   <System>
+#     <Provider Name="acvpnagent" /> 
+#     <EventID Qualifiers="25600">2079</EventID> 
+#     <Level>4</Level> 
+#     <Task>0</Task> 
+#     <Keywords>0x80000000000000</Keywords> 
+#     <TimeCreated SystemTime="2020-10-08T21:36:58.4956470Z" /> 
+#     <EventRecordID>7373</EventRecordID> 
+#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel> 
+#     <Computer>foobar</Computer> 
+#     <Security /> 
+#   </System>
+#   <EventData>
+#     <Data>Host Configuration: Public address: N/A Potential public addresses: Private Address: 10.1.1.1/8 Private IPv6 Address: FE80::1234/126 (auto-generated) Remote Peers: 2.1.1.1 (TCP port 443, UDP port 443), 2.1.1.1 (TCP port 80) Private Networks: none Private IPv6 Networks: none Public Networks: none Public IPv6 Networks: none Tunnel Mode: no Tunnel all DNS: no</Data> 
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2079.map
+++ b/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2079.map
@@ -3,34 +3,33 @@ Description: Cisco AnyConnect VPN Host Configuration
 EventId: 2079
 Channel: "Cisco AnyConnect Secure Mobility Client"
 Provider: acvpnagent
-Maps: 
-  - 
+Maps:
+  -
     Property: PayloadData1
     PropertyValue: "%PayloadData1%"
-    Values: 
-      - 
+    Values:
+      -
         Name: PayloadData1
         Value: "/Event/EventData/Data"
         Refine: "(?<=, )[^,\\d]+(?=,)"
 
-# Valid properties include:
-# 
-# PayloadData1
-
+# Documentation
+# N/A
+#
 # <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
 #   <System>
-#     <Provider Name="acvpnagent" /> 
-#     <EventID Qualifiers="25600">2079</EventID> 
-#     <Level>4</Level> 
-#     <Task>0</Task> 
-#     <Keywords>0x80000000000000</Keywords> 
-#     <TimeCreated SystemTime="2020-10-08T21:36:58.4956470Z" /> 
-#     <EventRecordID>7373</EventRecordID> 
-#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel> 
-#     <Computer>foobar</Computer> 
-#     <Security /> 
+#     <Provider Name="acvpnagent" />
+#     <EventID Qualifiers="25600">2079</EventID>
+#     <Level>4</Level>
+#     <Task>0</Task>
+#     <Keywords>0x80000000000000</Keywords>
+#     <TimeCreated SystemTime="2020-10-08T21:36:58.4956470Z" />
+#     <EventRecordID>7373</EventRecordID>
+#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel>
+#     <Computer>foobar</Computer>
+#     <Security />
 #   </System>
 #   <EventData>
-#     <Data>Host Configuration: Public address: N/A Potential public addresses: Private Address: 10.1.1.1/8 Private IPv6 Address: FE80::1234/126 (auto-generated) Remote Peers: 2.1.1.1 (TCP port 443, UDP port 443), 2.1.1.1 (TCP port 80) Private Networks: none Private IPv6 Networks: none Public Networks: none Public IPv6 Networks: none Tunnel Mode: no Tunnel all DNS: no</Data> 
+#     <Data>Host Configuration: Public address: N/A Potential public addresses: Private Address: 10.1.1.1/8 Private IPv6 Address: FE80::1234/126 (auto-generated) Remote Peers: 2.1.1.1 (TCP port 443, UDP port 443), 2.1.1.1 (TCP port 80) Private Networks: none Private IPv6 Networks: none Public Networks: none Public IPv6 Networks: none Tunnel Mode: no Tunnel all DNS: no</Data>
 #   </EventData>
 # </Event>

--- a/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2085.map
+++ b/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2085.map
@@ -1,36 +1,35 @@
-Author: esecrpm 
-Description: Cisco AnyConnect VPN client's public address 
+Author: esecrpm
+Description: Cisco AnyConnect VPN client's public address
 EventId: 2085
 Channel: "Cisco AnyConnect Secure Mobility Client"
 Provider: acvpnagent
-Maps: 
-  - 
+Maps:
+  -
     Property: PayloadData1
     PropertyValue: "%PayloadData1%"
-    Values: 
-      - 
+    Values:
+      -
         Name: PayloadData1
         Value: "/Event/EventData/Data"
         Refine: "(?<=, )[^,\\d]+(?=,)"
 
-# Valid properties include:
-# 
-# PayloadData1
-
+# Documentation
+# N/A
+#
 # <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
 #   <System>
-#     <Provider Name="acvpnagent" /> 
-#     <EventID Qualifiers="25600">2085</EventID> 
-#     <Level>4</Level> 
-#     <Task>0</Task> 
-#     <Keywords>0x80000000000000</Keywords> 
-#     <TimeCreated SystemTime="2021-02-02T13:01:47.262480100Z" /> 
-#     <EventRecordID>198651</EventRecordID> 
-#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel> 
-#     <Computer>foobar</Computer> 
-#     <Security /> 
+#     <Provider Name="acvpnagent" />
+#     <EventID Qualifiers="25600">2085</EventID>
+#     <Level>4</Level>
+#     <Task>0</Task>
+#     <Keywords>0x80000000000000</Keywords>
+#     <TimeCreated SystemTime="2021-02-02T13:01:47.262480100Z" />
+#     <EventRecordID>198651</EventRecordID>
+#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel>
+#     <Computer>foobar</Computer>
+#     <Security />
 #   </System>
 #   <EventData>
-#     <Data>The client's public address is now set to 192.168.1.1</Data> 
+#     <Data>The client's public address is now set to 192.168.1.1</Data>
 #   </EventData>
 # </Event>

--- a/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2085.map
+++ b/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnagent_2085.map
@@ -1,0 +1,36 @@
+Author: esecrpm 
+Description: Cisco AnyConnect VPN client's public address 
+EventId: 2085
+Channel: "Cisco AnyConnect Secure Mobility Client"
+Provider: acvpnagent
+Maps: 
+  - 
+    Property: PayloadData1
+    PropertyValue: "%PayloadData1%"
+    Values: 
+      - 
+        Name: PayloadData1
+        Value: "/Event/EventData/Data"
+        Refine: "(?<=, )[^,\\d]+(?=,)"
+
+# Valid properties include:
+# 
+# PayloadData1
+
+# <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+#   <System>
+#     <Provider Name="acvpnagent" /> 
+#     <EventID Qualifiers="25600">2085</EventID> 
+#     <Level>4</Level> 
+#     <Task>0</Task> 
+#     <Keywords>0x80000000000000</Keywords> 
+#     <TimeCreated SystemTime="2021-02-02T13:01:47.262480100Z" /> 
+#     <EventRecordID>198651</EventRecordID> 
+#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel> 
+#     <Computer>foobar</Computer> 
+#     <Security /> 
+#   </System>
+#   <EventData>
+#     <Data>The client's public address is now set to 192.168.1.1</Data> 
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnui_3021.map
+++ b/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnui_3021.map
@@ -13,10 +13,9 @@ Maps:
         Value: "/Event/EventData/Data"
         Refine: "(?<=, )[^,\\d]+(?=,)"
 
-# Valid properties include:
-# 
-# PayloadData1
-
+# Documentation
+# N/A
+#
 # <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
 #   <System>
 #     <Provider Name="acvpnui" /> 

--- a/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnui_3021.map
+++ b/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnui_3021.map
@@ -3,12 +3,12 @@ Description: Cisco AnyConnect VPN message sent to user
 EventId: 3021
 Channel: "Cisco AnyConnect Secure Mobility Client"
 Provider: acvpnui
-Maps: 
-  - 
+Maps:
+  -
     Property: PayloadData1
     PropertyValue: "%PayloadData1%"
-    Values: 
-      - 
+    Values:
+      -
         Name: PayloadData1
         Value: "/Event/EventData/Data"
         Refine: "(?<=, )[^,\\d]+(?=,)"
@@ -18,18 +18,18 @@ Maps:
 #
 # <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
 #   <System>
-#     <Provider Name="acvpnui" /> 
-#     <EventID Qualifiers="25600">3021</EventID> 
-#     <Level>4</Level> 
-#     <Task>0</Task> 
-#     <Keywords>0x80000000000000</Keywords> 
-#     <TimeCreated SystemTime="2020-10-08T15:58:28.7588300Z" /> 
-#     <EventRecordID>7050</EventRecordID> 
-#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel> 
-#     <Computer>foobar</Computer> 
-#     <Security /> 
+#     <Provider Name="acvpnui" />
+#     <EventID Qualifiers="25600">3021</EventID>
+#     <Level>4</Level>
+#     <Task>0</Task>
+#     <Keywords>0x80000000000000</Keywords>
+#     <TimeCreated SystemTime="2020-10-08T15:58:28.7588300Z" />
+#     <EventRecordID>7050</EventRecordID>
+#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel>
+#     <Computer>foobar</Computer>
+#     <Security />
 #   </System>
 #   <EventData>
-#      <Data>Message type information sent to the user: Establishing VPN session...</Data> 
+#      <Data>Message type information sent to the user: Establishing VPN session...</Data>
 #   </EventData>
 # </Event>

--- a/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnui_3021.map
+++ b/evtx/Maps/Cisco-AnyConnect-Secure-Mobility-Client_acvpnui_3021.map
@@ -1,0 +1,36 @@
+Author: esecrpm
+Description: Cisco AnyConnect VPN message sent to user
+EventId: 3021
+Channel: "Cisco AnyConnect Secure Mobility Client"
+Provider: acvpnui
+Maps: 
+  - 
+    Property: PayloadData1
+    PropertyValue: "%PayloadData1%"
+    Values: 
+      - 
+        Name: PayloadData1
+        Value: "/Event/EventData/Data"
+        Refine: "(?<=, )[^,\\d]+(?=,)"
+
+# Valid properties include:
+# 
+# PayloadData1
+
+# <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+#   <System>
+#     <Provider Name="acvpnui" /> 
+#     <EventID Qualifiers="25600">3021</EventID> 
+#     <Level>4</Level> 
+#     <Task>0</Task> 
+#     <Keywords>0x80000000000000</Keywords> 
+#     <TimeCreated SystemTime="2020-10-08T15:58:28.7588300Z" /> 
+#     <EventRecordID>7050</EventRecordID> 
+#     <Channel>Cisco AnyConnect Secure Mobility Client</Channel> 
+#     <Computer>foobar</Computer> 
+#     <Security /> 
+#   </System>
+#   <EventData>
+#      <Data>Message type information sent to the user: Establishing VPN session...</Data> 
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Microsoft-Windows-Dhcp-Client-Admin_Microsoft-Windows-Dhcp-Client_50067.map
+++ b/evtx/Maps/Microsoft-Windows-Dhcp-Client-Admin_Microsoft-Windows-Dhcp-Client_50067.map
@@ -1,0 +1,51 @@
+Author: esecrpm
+Description: Windows DHCP Client WiFi SSID Received
+EventId: 50067
+Channel: "Microsoft-Windows-Dhcp-Client/Admin"
+Provider: Microsoft-Windows-Dhcp-Client
+Maps: 
+  - 
+    Property: PayloadData1
+    PropertyValue: "SSID: %PayloadData1%"
+    Values: 
+      - 
+        Name: PayloadData1
+        Value: "/Event/EventData/Data[@Name=\"NetworkHint\"]"
+        Refine: "(?<=, )[^,\\d]+(?=,)"
+  - 
+    Property: PayloadData2
+    PropertyValue: "MAC Address: %PayloadData2%"
+    Values: 
+      - 
+        Name: PayloadData2
+        Value: "/Event/EventData/Data[@Name=\"HWAddress\"]"
+        Refine: "(?<=, )[^,\\d]+(?=,)"       
+
+# Valid properties include:
+# 
+# PayloadData1
+
+# <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+#   <System>
+#     <Provider Name="Microsoft-Windows-Dhcp-Client" Guid="{15a7a4f8-0072-4eab-abad-f98a4d666aed}" /> 
+#     <EventID>50067</EventID> 
+#     <Version>0</Version> 
+#     <Level>4</Level> 
+#     <Task>3</Task> 
+#     <Opcode>57</Opcode> 
+#     <Keywords>0x4000000000000000</Keywords> 
+#     <TimeCreated SystemTime="2020-10-08T22:11:09.9522595Z" /> 
+#     <EventRecordID>30</EventRecordID> 
+#     <Correlation /> 
+#     <Execution ProcessID="1912" ThreadID="2308" /> 
+#     <Channel>Microsoft-Windows-Dhcp-Client/Admin</Channel> 
+#     <Computer>foobar</Computer> 
+#     <Security UserID="S-1-5-19" /> 
+#   </System>
+#   <EventData>
+#     <Data Name="NetworkHintString">WiFi_SSID</Data> 
+#     <Data Name="NetworkHint">576946695F53534944</Data> 
+#     <Data Name="HWLength">6</Data> 
+#     <Data Name="HWAddress">001122334455</Data> 
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Microsoft-Windows-Dhcp-Client-Admin_Microsoft-Windows-Dhcp-Client_50067.map
+++ b/evtx/Maps/Microsoft-Windows-Dhcp-Client-Admin_Microsoft-Windows-Dhcp-Client_50067.map
@@ -3,49 +3,48 @@ Description: Windows DHCP Client WiFi SSID Received
 EventId: 50067
 Channel: "Microsoft-Windows-Dhcp-Client/Admin"
 Provider: Microsoft-Windows-Dhcp-Client
-Maps: 
-  - 
+Maps:
+  -
     Property: PayloadData1
     PropertyValue: "SSID: %PayloadData1%"
-    Values: 
-      - 
+    Values:
+      -
         Name: PayloadData1
         Value: "/Event/EventData/Data[@Name=\"NetworkHint\"]"
         Refine: "(?<=, )[^,\\d]+(?=,)"
-  - 
+  -
     Property: PayloadData2
     PropertyValue: "MAC Address: %PayloadData2%"
-    Values: 
-      - 
+    Values:
+      -
         Name: PayloadData2
         Value: "/Event/EventData/Data[@Name=\"HWAddress\"]"
-        Refine: "(?<=, )[^,\\d]+(?=,)"       
+        Refine: "(?<=, )[^,\\d]+(?=,)"
 
-# Valid properties include:
-# 
-# PayloadData1
-
+# Documentation
+# N/A
+#
 # <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
 #   <System>
-#     <Provider Name="Microsoft-Windows-Dhcp-Client" Guid="{15a7a4f8-0072-4eab-abad-f98a4d666aed}" /> 
-#     <EventID>50067</EventID> 
-#     <Version>0</Version> 
-#     <Level>4</Level> 
-#     <Task>3</Task> 
-#     <Opcode>57</Opcode> 
-#     <Keywords>0x4000000000000000</Keywords> 
-#     <TimeCreated SystemTime="2020-10-08T22:11:09.9522595Z" /> 
-#     <EventRecordID>30</EventRecordID> 
-#     <Correlation /> 
-#     <Execution ProcessID="1912" ThreadID="2308" /> 
-#     <Channel>Microsoft-Windows-Dhcp-Client/Admin</Channel> 
-#     <Computer>foobar</Computer> 
-#     <Security UserID="S-1-5-19" /> 
+#     <Provider Name="Microsoft-Windows-Dhcp-Client" Guid="{15a7a4f8-0072-4eab-abad-f98a4d666aed}" />
+#     <EventID>50067</EventID>
+#     <Version>0</Version>
+#     <Level>4</Level>
+#     <Task>3</Task>
+#     <Opcode>57</Opcode>
+#     <Keywords>0x4000000000000000</Keywords>
+#     <TimeCreated SystemTime="2020-10-08T22:11:09.9522595Z" />
+#     <EventRecordID>30</EventRecordID>
+#     <Correlation />
+#     <Execution ProcessID="1912" ThreadID="2308" />
+#     <Channel>Microsoft-Windows-Dhcp-Client/Admin</Channel>
+#     <Computer>foobar</Computer>
+#     <Security UserID="S-1-5-19" />
 #   </System>
 #   <EventData>
-#     <Data Name="NetworkHintString">WiFi_SSID</Data> 
-#     <Data Name="NetworkHint">576946695F53534944</Data> 
-#     <Data Name="HWLength">6</Data> 
-#     <Data Name="HWAddress">001122334455</Data> 
+#     <Data Name="NetworkHintString">WiFi_SSID</Data>
+#     <Data Name="NetworkHint">576946695F53534944</Data>
+#     <Data Name="HWLength">6</Data>
+#     <Data Name="HWAddress">001122334455</Data>
 #   </EventData>
 # </Event>

--- a/evtx/Maps/Microsoft-Windows-PrintService-Operational_Microsoft-Windows-PrintService_307.map
+++ b/evtx/Maps/Microsoft-Windows-PrintService-Operational_Microsoft-Windows-PrintService_307.map
@@ -49,7 +49,6 @@ Maps:
 
 # Documentation:
 # https://eventlogxp.com/blog/how-to-track-printer-usage-with-event-logs
-#
 # The document name is not recorded in the event record until enabled via Group Policy
 # https://social.technet.microsoft.com/Forums/ie/en-US/12e60098-1f46-4c6e-8b10-9c816dadb2b2/kb-fix-for-print-document-name-in-event-logs-on-server-2012-and-server-2012r2?forum=winserverprint
 #

--- a/evtx/Maps/Microsoft-Windows-PrintService-Operational_Microsoft-Windows-PrintService_307.map
+++ b/evtx/Maps/Microsoft-Windows-PrintService-Operational_Microsoft-Windows-PrintService_307.map
@@ -13,25 +13,25 @@ Maps:
         Value: "/Event/UserData/DocumentPrinted/Param3"
   -
     Property: PayloadData2
-    PropertyValue: "Print Host: %PrintHost%"
-    Values:
-      -
-        Name: PrintHost
-        Value: "/Event/UserData/DocumentPrinted/Param4"
-  -
-    Property: PayloadData3
     PropertyValue: "Printer Name: %PrinterName%"
     Values:
       -
         Name: PrinterName
         Value: "/Event/UserData/DocumentPrinted/Param5"
   -
-    Property: PayloadData4
+    Property: PayloadData3
     PropertyValue: "Document Name: %DocumentName%"
     Values:
       -
         Name: DocumentName
         Value: "/Event/UserData/DocumentPrinted/Param2"
+  -
+    Property: PayloadData4
+    PropertyValue: "Printer Port: %PrinterPort%"
+    Values:
+      -
+        Name: PrinterPort
+        Value: "/Event/UserData/DocumentPrinted/Param4"
   -
     Property: PayloadData5
     PropertyValue: "Size in Bytes: %Bytes%"


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [X] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [X] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [X] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [X] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
