### PR TITLE
Sentinel One

### DIFF
--- a/evtx/Maps/SentinelOne-Operational_91.map
+++ b/evtx/Maps/SentinelOne-Operational_91.map
@@ -28,6 +28,7 @@ Maps:
 
 # Documentation:
 # Script Logging Attempted
+#
 # Example Event Data:
 # <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
 #  <System>


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [x] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [x] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [x] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [x] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
