### PR TITLE
Create Security_Microsoft-Windows-Security-Auditing_4797.map

### DIFF
--- a/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4797.map
+++ b/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4797.map
@@ -1,0 +1,76 @@
+Author: Andrew Rathbun
+Description: An attempt was made to query the existence of a blank password for an account
+EventId: 4797
+Channel: Security
+Provider: Microsoft-Windows-Security-Auditing
+Maps:
+  -
+    Property: UserName
+    PropertyValue: "%domain%\\%user% (%sid%)"
+    Values:
+      -
+        Name: domain
+        Value: "/Event/EventData/Data[@Name=\"SubjectDomainName\"]"
+      -
+        Name: user
+        Value: "/Event/EventData/Data[@Name=\"SubjectUserName\"]"
+      -
+        Name: sid
+        Value: "/Event/EventData/Data[@Name=\"SubjectUserSid\"]"
+  -
+    Property: PayloadData1
+    PropertyValue: "Target: %TargetDomainName%\\%TargetUserName%"
+    Values:
+      -
+        Name: TargetUserName
+        Value: "/Event/EventData/Data[@Name=\"TargetUserName\"]"
+      -
+        Name: TargetDomainName
+        Value: "/Event/EventData/Data[@Name=\"TargetDomainName\"]"
+  -
+    Property: PayloadData2
+    PropertyValue: "SubjectLogonId: %SubjectLogonId%"
+    Values:
+      -
+        Name: SubjectLogonId
+        Value: "/Event/EventData/Data[@Name=\"SubjectLogonId\"]"
+  -
+    Property: PayloadData3
+    PropertyValue: "Workstation: %Workstation%"
+    Values:
+      -
+        Name: Workstation
+        Value: "/Event/EventData/Data[@Name=\"Workstation\"]"
+
+# Documentation:
+# https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=4797
+# https://docs.microsoft.com/en-us/answers/questions/246751/what-condition-will-trigger-event-id-4797-an-attem.html
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="Microsoft-Windows-Security-Auditing" Guid="54849625-5478-4994-a5ba-3e3b6798c30d" />
+#     <EventID>4797</EventID>
+#     <Version>0</Version>
+#     <Level>0</Level>
+#     <Task>13824</Task>
+#     <Opcode>0</Opcode>
+#     <Keywords>0x8020000000000000</Keywords>
+#     <TimeCreated SystemTime="2021-07-21 08:38:40.5035194" />
+#     <EventRecordID>2882305</EventRecordID>
+#     <Correlation ActivityID="f5b29056-746c-0000-9990-b2f56c74d701" />
+#     <Execution ProcessID="656" ThreadID="15220" />
+#     <Channel>Security</Channel>
+#     <Computer>HOSTNAME.domain</Computer>
+#     <Security />
+#   </System>
+#   <EventData>
+#     <Data Name="SubjectUserSid">S-1-5-21-12345678-12345678-112345678-1234</Data>
+#     <Data Name="SubjectUserName">Username</Data>
+#     <Data Name="SubjectDomainName">Domain</Data>
+#     <Data Name="SubjectLogonId">0x32012CAF</Data>
+#     <Data Name="Workstation">HOSTNAME</Data>
+#     <Data Name="TargetUserName">Username</Data>
+#     <Data Name="TargetDomainName">Domain</Data>
+#   </EventData>
+# </Event>


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [x] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [x] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [x] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [x] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
