### PR TITLE
Create Security_Microsoft-Windows-Security-Auditing_4743.map

### DIFF
--- a/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4743.map
+++ b/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4743.map
@@ -1,0 +1,73 @@
+Author: Andrew Rathbun
+Description: A computer account was deleted
+EventId: 4743
+Channel: Security
+Provider: Microsoft-Windows-Security-Auditing
+Maps:
+  -
+    Property: UserName
+    PropertyValue: "%domain%\\%user% (%sid%)"
+    Values:
+      -
+        Name: domain
+        Value: "/Event/EventData/Data[@Name=\"SubjectDomainName\"]"
+      -
+        Name: user
+        Value: "/Event/EventData/Data[@Name=\"SubjectUserName\"]"
+      -
+        Name: sid
+        Value: "/Event/EventData/Data[@Name=\"SubjectUserSid\"]"
+  -
+    Property: PayloadData1
+    PropertyValue: "Target: %domain%\\%user% (%sid%)"
+    Values:
+      -
+        Name: domain
+        Value: "/Event/EventData/Data[@Name=\"TargetDomainName\"]"
+      -
+        Name: user
+        Value: "/Event/EventData/Data[@Name=\"TargetUserName\"]"
+      -
+        Name: sid
+        Value: "/Event/EventData/Data[@Name=\"TargetUserSid\"]"
+  -
+    Property: PayloadData2
+    PropertyValue: "SubjectLogonId: %SubjectLogonId%"
+    Values:
+      -
+        Name: SubjectLogonId
+        Value: "/Event/EventData/Data[@Name=\"SubjectLogonId\"]"
+
+# Documentation:
+# https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=4743
+# https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4743
+#
+# Example Event Data:
+# <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+# 	<System>
+# 		<Provider Name="Microsoft-Windows-Security-Auditing" Guid="{54849625-5478-4994-A5BA-3E3B0328C30D}" />
+# 		<EventID>4743</EventID>
+# 		<Version>0</Version>
+# 		<Level>0</Level>
+# 		<Task>13825</Task>
+# 		<Opcode>0</Opcode>
+# 		<Keywords>0x8020000000000000</Keywords>
+# 		<TimeCreated SystemTime="2015-08-14T15:57:08.104214100Z" />
+# 		<EventRecordID>172103</EventRecordID>
+# 		<Correlation />
+# 		<Execution ProcessID="520" ThreadID="1108" />
+# 		<Channel>Security</Channel>
+# 		<Computer>DC01.contoso.local</Computer>
+# 		<Security />
+# 	</System>
+# 	<EventData>
+# 		<Data Name="TargetUserName">COMPUTERACCOUNT$</Data>
+# 		<Data Name="TargetDomainName">CONTOSO</Data>
+# 		<Data Name="TargetSid">S-1-5-21-3457937927-2839227994-823803824-6118</Data>
+# 		<Data Name="SubjectUserSid">S-1-5-21-3457937927-2839227994-823803824-1104</Data>
+# 		<Data Name="SubjectUserName">dadmin</Data>
+# 		<Data Name="SubjectDomainName">CONTOSO</Data>
+# 		<Data Name="SubjectLogonId">0x3007b</Data>
+# 		<Data Name="PrivilegeList">-</Data>
+# 	</EventData>
+# </Event>


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [x] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [x] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [x] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [x] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [ ] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
