### PR TITLE
Update Microsoft-Windows-Partition-Diagnostic_Microsoft-Windows-Parti…

### DIFF
--- a/evtx/Maps/Microsoft-Windows-Partition-Diagnostic_Microsoft-Windows-Partition_1006.map
+++ b/evtx/Maps/Microsoft-Windows-Partition-Diagnostic_Microsoft-Windows-Partition_1006.map
@@ -1,4 +1,4 @@
-Author: Mark Hallman mark.hallman@gmail.com, Hyun Yi @hyuunnn, Andrew Rathbun
+Author: Mark Hallman mark.hallman@gmail.com, Hyun Yi @hyuunnn, Andrew Rathbun, Chad Tilbury
 Description: USB Insertion/Removal
 EventId: 1006
 Channel: "Microsoft-Windows-Partition/Diagnostic"
@@ -27,18 +27,18 @@ Maps:
         Value: "/Event/EventData/Data[@Name=\"Manufacturer\"]"
   -
     Property: PayloadData4
-    PropertyValue: "SerialNumber: %SerialNumber%"
+    PropertyValue: "SCSI SerialNumber: %SerialNumber%"
     Values:
       -
         Name: SerialNumber
         Value: "/Event/EventData/Data[@Name=\"SerialNumber\"]"
   -
     Property: PayloadData5
-    PropertyValue: "DiskId: %DiskId%"
+    PropertyValue: "RegistryId: %RegistryId%"
     Values:
       -
-        Name: DiskId
-        Value: "/Event/EventData/Data[@Name=\"DiskId\"]"
+        Name: RegistryId
+        Value: "/Event/EventData/Data[@Name=\"RegistryId\"]"
   -
     Property: PayloadData6
     PropertyValue: "ParentId: %ParentId%"
@@ -54,6 +54,9 @@ Maps:
 # https://forensixchange.com/posts/19_08_03_usb_storage_forensics_1/
 # https://docs.microsoft.com/en-us/previous-versions/windows/desktop/stormgmt/msft-physicaldisk (BusType)
 # Frankly, there is too much data to fit within 6 PayloadData columns. As always, all data is in the Payload column but there isn't enough room to map out all the information cleanly.
+#
+# SCSI SerialNumber is not always the same as iSerialNumber (found in USBSTOR registry key).  This is a secondary serial number.
+# Search for the RegistryID within the SYSTEM hive to match with the proper USBSTOR key and iSerialNumber. 
 #
 # Example Event Data:
 # <Event>


### PR DESCRIPTION
…tion_1006.map

Updated map to properly label available device serial number and to change to more valuable RegistryID for mapping device back to the SYSTEM registry hive.

## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [X ] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [ X] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [X ] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [NA ] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [X ] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
