### PR TITLE
suggested change as file name != executable name

### DIFF
--- a/evtx/Maps/Microsoft-Windows-SMBServer-Operational_Microsoft-Windows-SMBServer_1020.map
+++ b/evtx/Maps/Microsoft-Windows-SMBServer-Operational_Microsoft-Windows-SMBServer_1020.map
@@ -19,13 +19,6 @@ Maps:
         Name: ClientName
         Value: "/Event/UserData/EventData/ClientName"
   -
-    Property: ExecutableInfo
-    PropertyValue: "FileName: %FileName%"
-    Values:
-      -
-        Name: FileName
-        Value: "/Event/UserData/EventData/FileName"
-  -
     Property: PayloadData1
     PropertyValue: "ShareName: %ShareName%"
     Values:
@@ -34,13 +27,20 @@ Maps:
         Value: "/Event/UserData/EventData/ShareName"
   -
     Property: PayloadData2
+    PropertyValue: "FileName: %FileName%"
+    Values:
+      -
+        Name: FileName
+        Value: "/Event/UserData/EventData/FileName"
+  -
+    Property: PayloadData3
     PropertyValue: "The threshold is %Threshold% milliseconds (15 seconds)"
     Values:
       -
         Name: Threshold
         Value: "/Event/UserData/EventData/Threshold"
   -
-    Property: PayloadData3
+    Property: PayloadData4
     PropertyValue: "The I/O operation took %Duration% milliseconds"
     Values:
       -


### PR DESCRIPTION
suggested change as in a large number of SMB failures the executable wouldn't be the interacted file the failure occurred on
suggest moving it to a payload instead

## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [x] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [ ] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [x] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [x] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [x] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
