### PR TITLE
Minor updates of 1006-4624-4648-5379-30807

### DIFF
--- a/evtx/Maps/Microsoft-Windows-Partition-Diagnostic_Microsoft-Windows-Partition_1006.map
+++ b/evtx/Maps/Microsoft-Windows-Partition-Diagnostic_Microsoft-Windows-Partition_1006.map
@@ -1,5 +1,5 @@
-Author: Mark Hallman mark.hallman@gmail.com, Hyun Yi @hyuunnn, Andrew Rathbun, Chad Tilbury
-Description: USB Insertion/Removal
+Author: Mark Hallman mark.hallman@gmail.com, Hyun Yi @hyuunnn, Andrew Rathbun, Chad Tilbury, Gabriele Zambelli
+Description: USB/VHD Insertion/Removal
 EventId: 1006
 Channel: "Microsoft-Windows-Partition/Diagnostic"
 Provider: Microsoft-Windows-Partition
@@ -46,6 +46,13 @@ Maps:
       -
         Name: ParentId
         Value: "/Event/EventData/Data[@Name=\"ParentId\"]"
+  -
+    Property: ExecutableInfo
+    PropertyValue: "Location: %Location%"
+    Values:
+      -
+        Name: Location
+        Value: "/Event/EventData/Data[@Name=\"Location\"]"
 
 # Documentation:
 # https://www.atropos4n6.com/windows/extract-vsns-that-reside-in-windows-partition4diagnostic-evtx/
@@ -159,4 +166,100 @@ Maps:
 #    <Data Name="Vbr3Size">0</Data>
 #    <Data Name="Vbr3"></Data>
 #  </EventData>
+# </Event>
+#
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="Microsoft-Windows-Partition" Guid="412bdff2-a8c4-470d-8f33-63fe0d8c20e2" />
+#     <EventID>1006</EventID>
+#     <Version>0</Version>
+#     <Level>4</Level>
+#     <Task>0</Task>
+#     <Opcode>0</Opcode>
+#     <Keywords>0x8000000000000000</Keywords>
+#     <TimeCreated SystemTime="2022-06-18 18:08:56.2583872" />
+#     <EventRecordID>8</EventRecordID>
+#     <Correlation />
+#     <Execution ProcessID="4" ThreadID="6140" />
+#     <Channel>Microsoft-Windows-Partition/Diagnostic</Channel>
+#     <Computer>VMWIN10</Computer>
+#     <Security UserID="S-1-5-18" />
+#   </System>
+#   <EventData>
+#     <Data Name="Version">3</Data>
+#     <Data Name="DiskNumber">1</Data>
+#     <Data Name="Flags">8208</Data>
+#     <Data Name="Characteristics">256</Data>
+#     <Data Name="IsSystemCritical">False</Data>
+#     <Data Name="PagingCount">0</Data>
+#     <Data Name="HibernationCount">0</Data>
+#     <Data Name="DumpCount">0</Data>
+#     <Data Name="BytesPerSector">512</Data>
+#     <Data Name="Capacity">5368709120</Data>
+#     <Data Name="BusType">15</Data>
+#     <Data Name="Manufacturer">Msft</Data>
+#     <Data Name="Model">Virtual Disk</Data>
+#     <Data Name="Revision">1.0</Data>
+#     <Data Name="SerialNumber">NULL</Data>
+#     <Data Name="Location">C:\Users\Administrator\Documents\TEST.vhdx</Data>
+#     <Data Name="ParentId">{8e7bd593-6e6c-4c52-86a6-77175494dd8e}\MsVhdHba\1&amp;amp;3030e83&amp;amp;0&amp;amp;01</Data>
+#     <Data Name="IoctlSupport">59903</Data>
+#     <Data Name="IdFlags">4</Data>
+#     <Data Name="DiskId">07040c5a-d416-d0d8-a712-aaa26504f23f</Data>
+#     <Data Name="AdapterId">38f6b6ae-ef2a-11ec-a14b-000c2931d7bf</Data>
+#     <Data Name="RegistryId">38f6b6af-ef2a-11ec-a14b-000c2931d7bf</Data>
+#     <Data Name="PoolId">00000000-0000-0000-0000-000000000000</Data>
+#     <Data Name="FirmwareSupportsUpgrade">True</Data>
+#     <Data Name="FirmwareSlotCount">1</Data>
+#     <Data Name="StorageIdCount">2</Data>
+#     <Data Name="StorageIdCodeSet">1</Data>
+#     <Data Name="StorageIdType">3</Data>
+#     <Data Name="StorageIdAssociation">0</Data>
+#     <Data Name="StorageIdBytes">16</Data>
+#     <Data Name="StorageId">60-02-24-80-0D-B5-E4-FA-29-F5-69-0A-86-D4-A7-B2</Data>
+#     <Data Name="WriteCacheType">2</Data>
+#     <Data Name="WriteCacheEnabled">2</Data>
+#     <Data Name="WriteCacheChangeable">2</Data>
+#     <Data Name="WriteThroughSupported">1</Data>
+#     <Data Name="FlushCacheSupported">True</Data>
+#     <Data Name="IsPowerProtected">False</Data>
+#     <Data Name="NVCacheEnabled">False</Data>
+#     <Data Name="BytesPerLogicalSector">512</Data>
+#     <Data Name="BytesPerPhysicalSector">4096</Data>
+#     <Data Name="BytesOffsetForSectorAlignment">0</Data>
+#     <Data Name="IncursSeekPenalty">False</Data>
+#     <Data Name="IsTrimSupported">True</Data>
+#     <Data Name="IsThinProvisioned">True</Data>
+#     <Data Name="OptimalUnmapGranularity">33554432</Data>
+#     <Data Name="UnmapAlignment">0</Data>
+#     <Data Name="NumberOfLogicalCopies">0</Data>
+#     <Data Name="NumberOfPhysicalCopies">0</Data>
+#     <Data Name="FaultTolerance">0</Data>
+#     <Data Name="NumberOfColumns">0</Data>
+#     <Data Name="InterleaveBytes">0</Data>
+#     <Data Name="HybridSupported">False</Data>
+#     <Data Name="HybridCacheBytes">0</Data>
+#     <Data Name="AdapterMaximumTransferBytes">8388608</Data>
+#     <Data Name="AdapterMaximumTransferPages">4294967295</Data>
+#     <Data Name="AdapterAlignmentMask">1</Data>
+#     <Data Name="AdapterSerialNumber">NULL</Data>
+#     <Data Name="PortDriver">1</Data>
+#     <Data Name="UserRemovalPolicy">False</Data>
+#     <Data Name="PartitionStyle">0</Data>
+#     <Data Name="PartitionCount">0</Data>
+#     <Data Name="PartitionTableBytes">48</Data>
+#     <Data Name="PartitionTable">00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00</Data>
+#     <Data Name="MbrBytes">512</Data>
+#     <Data Name="Mbr">00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00</Data>
+#     <Data Name="Vbr0Bytes">0</Data>
+#     <Data Name="Vbr0"></Data>
+#     <Data Name="Vbr1Bytes">0</Data>
+#     <Data Name="Vbr1"></Data>
+#     <Data Name="Vbr2Bytes">0</Data>
+#     <Data Name="Vbr2"></Data>
+#     <Data Name="Vbr3Size">0</Data>
+#     <Data Name="Vbr3"></Data>
+#   </EventData>
 # </Event>

--- a/evtx/Maps/Microsoft-Windows-SmbClient-Connectivity_Microsoft-Windows-SMBClient_30807.map
+++ b/evtx/Maps/Microsoft-Windows-SmbClient-Connectivity_Microsoft-Windows-SMBClient_30807.map
@@ -1,4 +1,4 @@
-Author: Andrew Rathbun
+Author: Andrew Rathbun, Gabriele Zambelli
 Description: The connection to the share was lost
 EventId: 30807
 Channel: "Microsoft-Windows-SmbClient/Connectivity"
@@ -33,8 +33,1792 @@ Maps:
         Name: Address
         Value: "/Event/EventData/Data[@Name=\"Address\"]"
 
+Lookups:
+  -
+    Name: Status
+    Default: Unknown code
+    Values:
+      1: The caller specified WaitAny for WaitType and one of the dispatcher objects in the Object array has been set to the signaled state
+      2: The caller specified WaitAny for WaitType and one of the dispatcher objects in the Object array has been set to the signaled state
+      3: The caller specified WaitAny for WaitType and one of the dispatcher objects in the Object array has been set to the signaled state
+      63: The caller specified WaitAny for WaitType and one of the dispatcher objects in the Object array has been set to the signaled state
+      128: The caller attempted to wait for a mutex that has been abandoned
+      191: The caller attempted to wait for a mutex that has been abandoned
+      192: A user-mode APC was delivered before the given Interval expired
+      257: The delay completed because the thread was alerted
+      258: The given Timeout interval expired
+      259: The operation that was requested is pending completion
+      260: A reparse should be performed by the Object Manager because the name of the file resulted in a symbolic link
+      261: Returned by enumeration APIs to indicate more information is available to successive calls
+      262: Indicates not all privileges or groups that are referenced are assigned to the caller. This allows, for example, all privileges to be disabled without having to know exactly which privileges are assigned
+      263: Some of the information to be translated has not been translated
+      264: An open/create operation completed while an opportunistic lock (oplock) break is underway
+      265: A new volume has been mounted by a file system
+      266: This success level status indicates that the transaction state already exists for the registry subtree but that a transaction commit was previously aborted. The commit has now been completed
+      267: Indicates that a notify change request has been completed due to closing the handle that made the notify change request
+      268: Indicates that a notify change request is being completed and that the information is not being returned in the caller's buffer. The caller now needs to enumerate the files to find the changes
+      269: No system quota limits are specifically set for this account
+      270: Connect Failure on Primary Transport
+      272: The page fault was a transition fault
+      273: The page fault was a demand zero fault
+      274: The page fault was a demand zero fault
+      275: The page fault was a demand zero fault
+      276: The page fault was satisfied by reading from a secondary storage device
+      277: The cached page was locked during operation
+      278: The crash dump exists in a paging file
+      279: The specified buffer contains all zeros
+      280: A reparse should be performed by the Object Manager because the name of the file resulted in a symbolic link
+      281: The device has succeeded a query-stop and its resource requirements have changed
+      288: The translator has translated these resources into the global space and no additional translations should be performed
+      289: The directory service evaluated group memberships locally, because it was unable to contact a global catalog server
+      290: A process being terminated has no threads to terminate
+      291: The specified process is not part of a job
+      292: The specified process is part of a job
+      293: Volume Shadow Copy Service - The system is now ready for hibernation
+      294: A file system or file system filter driver has successfully completed an FsFilter operation
+      295: The specified interrupt vector was already connected
+      296: The specified interrupt vector is still connected
+      297: The current process is a cloned process
+      298: The file was locked and all users of the file can only read
+      299: The file was locked and at least one user of the file can write
+      514: The specified ResourceManager made no changes or updates to the resource under this transaction
+      871: An operation is blocked and waiting for an oplock
+      65537: Debugger handled the exception
+      65538: The debugger continued
+      1835009: The IO was completed by a filter
+      3221226599: The file is temporarily unavailable
+      3221227297: A threadpool worker thread entered a callback at thread affinity %p and exited at affinity %p
+      1073741824: An attempt was made to create an object but the object name already exists
+      1073741825: A thread termination occurred while the thread was suspended. The thread resumed, and termination proceeded
+      1073741826: An attempt was made to set the working set minimum or maximum to values that are outside the allowable range
+      1073741827: An image file could not be mapped at the address that is specified in the image file. Local fixes must be performed on this image
+      1073741828: This informational level status indicates that a specified registry subtree transaction state did not yet exist and had to be created
+      1073741829: A virtual DOS machine (VDM) is loading, unloading, or moving an MS-DOS or Win16 program segment image. An exception is raised so that a debugger can load, unload, or track symbols and breakpoints within these 16-bit segments
+      1073741830: A user session key was requested for a local remote procedure call (RPC) connection. The session key that is returned is a constant value and not unique to this connection
+      1073741831: The process cannot switch to the startup current directory
+      1073741832: A serial I/O operation was completed by another write to a serial port
+      1073741833: One of the files that contains the system registry data had to be recovered by using a log or alternate copy. The recovery was successful
+      1073741834: To satisfy a read request, the Windows NT fault-tolerant file system successfully read the requested data from a redundant copy. This was done because the file system encountered a failure on a member of the fault-tolerant volume but was unable to reassign the failing area of the device
+      1073741835: To satisfy a write request, the Windows NT fault-tolerant file system successfully wrote a redundant copy of the information. This was done because the file system encountered a failure on a member of the fault-tolerant volume but was unable to reassign the failing area of the device
+      1073741836: A serial I/O operation completed because the time-out period expired. (The IOCTL_SERIAL_XOFF_COUNTER had not reached zero.
+      1073741837: Password Too Complex - The Windows password is too complex to be converted to a LAN Manager password. The LAN Manager password that returned is a NULL string
+      1073741838: Machine Type Mismatch
+      1073741839: Partial Data Received - The network transport returned partial data to its client. The remaining data will be sent later
+      1073741840: Expedited Data Received - The network transport returned data to its client that was marked as expedited by the remote system
+      1073741841: Partial Expedited Data Received - The network transport returned partial data to its client and this data was marked as expedited by the remote system. The remaining data will be sent later
+      1073741842: TDI Event Done - The TDI indication has completed successfully
+      1073741843: TDI Event Pending - The TDI indication has entered the pending state
+      1073741844: Checking file system on %wZ
+      1073741845: Fatal Application Exit
+      1073741846: The specified registry key is referenced by a predefined handle
+      1073741847: Page Unlocked - The page protection of a locked page was changed to 'No Access' and the page was unlocked from memory and from the process
+      1073741849: Page Locked - One of the pages to lock was already locked
+      1073741850: Application popup
+      1073741851: A Win32 process already exists
+      1073741852: An exception status code that is used by the Win32 x86 emulation subsystem
+      1073741853: An exception status code that is used by the Win32 x86 emulation subsystem
+      1073741854: An exception status code that is used by the Win32 x86 emulation subsystem
+      1073741855: An exception status code that is used by the Win32 x86 emulation subsystem
+      1073741856: An exception status code that is used by the Win32 x86 emulation subsystem
+      1073741857: An exception status code that is used by the Win32 x86 emulation subsystem
+      1073741858: An exception status code that is used by the Win32 x86 emulation subsystem
+      1073741859: Machine Type Mismatch
+      1073741860: A yield execution was performed and no thread was available to run
+      1073741861: The resume flag to a timer API was ignored
+      1073741862: The arbiter has deferred arbitration of these resources to its parent
+      1073741863: The device has detected a CardBus card in its slot
+      1073741864: An exception status code that is used by the Win32 x86 emulation subsystem
+      1073741865: The CPUs in this multiprocessor system are not all the same revision level. To use all processors, the operating system restricts itself to the features of the least capable processor in the system. If problems occur with this system, contact the CPU manufacturer to see if this mix of processors is supported
+      1073741866: The system was put into hibernation
+      1073741867: The system was resumed from hibernation
+      1073741868: 0x4000002D<br />STATUS_DRIVERS_LEAKING_LOCKED_PAGES]
+      1073741870: The ALPC message being canceled has already been retrieved from the queue on the other side
+      1073741871: The system power state is transitioning from %2 to %3
+      1073741872: The receive operation was successful. Check the ALPC completion list for the received message
+      1073741873: The system power state is transitioning from %2 to %3 but could enter %4
+      1073741874: Access to %1 is monitored by policy rule %2
+      1073741875: A valid hibernation file has been invalidated and should be abandoned
+      1073741876: Business rule scripts are disabled for the calling application
+      1073742484: The system has awoken
+      1073742704: The directory service is shutting down
+      1073807361: Debugger will reply later
+      1073807362: Debugger cannot provide a handle
+      1073807363: Debugger terminated the thread
+      1073807364: Debugger terminated the process
+      1073807365: Debugger obtained control of C
+      1073807366: Debugger printed an exception on control C
+      1073807367: Debugger received a RIP exception
+      1073807368: Debugger received a control break
+      1073807369: Debugger command communication exception
+      1073872982: A UUID that is valid only on this computer has been allocated
+      1073873071: Some data remains to be sent in the request buffer
+      1074397188: The Client Drive Mapping Service has connected on Terminal Connection
+      1074397189: The Client Drive Mapping Service has disconnected on Terminal Connection
+      1075118093: A kernel mode component is releasing a reference on an activation context
+      1075380276: The transactional resource manager is already consistent. Recovery is not needed
+      1075380277: The transactional resource manager has already been started
+      1075445772: The log service encountered a log stream with no restart area
+      1075511532: Display Driver Recovered From Failure
+      1075707914: The specified buffer is not big enough to contain the entire requested dataset. Partial data is populated up to the size of the buffer
+      1075708183: The kernel driver detected a version mismatch between it and the user mode driver
+      1075708679: No mode is pinned on the specified VidPN source/target
+      1075708702: The specified mode set does not specify a preference for one of its modes
+      1075708747: The specified dataset (for example, mode set, frequency range set, descriptor set, or topology) is empty
+      1075708748: The specified dataset (for example, mode set, frequency range set, descriptor set, or topology) does not contain any more elements
+      1075708753: The specified content transformation is not pinned on the specified VidPN present path
+      1075708975: The child device presence was not reliably detected
+      1075708983: Starting the lead adapter in a linked configuration has been temporarily deferred
+      1075708985: The display adapter is being polled for children too frequently at the same polling level
+      1075708986: Starting the adapter has been temporarily deferred
+      1076035585: The request will be completed later by an NDIS status indication
+      2147483649: Guard Page Exception A page of memory that marks the end of a data structure, such as a stack or an array, has been accessed
+      2147483650: Alignment Fault A data type misalignment was detected in a load or store instruction
+      2147483651: Breakpoint A breakpoint has been reached
+      2147483652: Single Step A single step or trace operation has just been completed
+      2147483653: Buffer Overflow - The data was too large to fit into the specified buffer
+      2147483654: No More Files - No more files were found which match the file specification
+      2147483655: Kernel Debugger Awakened - The system debugger was awakened by an interrupt
+      2147483658: Handles Closed - Handles to objects have been automatically closed because of the requested operation
+      2147483659: An access control list (ACL) contains no components that can be inherited
+      2147483660: GUID Substitution
+      2147483661: Because of protection conflicts, not all the requested bytes could be copied
+      2147483663: Device Power Is Off - The printer power has been turned off
+      2147483664: Device Offline - The printer has been taken offline
+      2147483665: Device Busy - The device is currently busy
+      2147483666: No more extended attributes (EAs) were found for the file
+      2147483667: The specified extended attribute (EA) name contains at least one illegal character
+      2147483668: The extended attribute (EA) list is inconsistent
+      2147483669: An invalid extended attribute (EA) flag was set
+      2147483670: The media has changed and a verify operation is in progress; therefore, no reads or writes may be performed to the device, except those that are used in the verify operation
+      2147483671: Too Much Information - The specified access control list (ACL) contained more information than was expected
+      2147483672: This warning level status indicates that the transaction state already exists for the registry subtree, but that a transaction commit was previously aborted. The commit has NOT been completed but has not been rolled back either; therefore, it may still be committed, if needed
+      2147483674: No more entries are available from an enumeration operation
+      2147483675: A filemark was detected
+      2147483676: The media may have changed
+      2147483677: An I/O bus reset was detected
+      2147483678: The end of the media was encountered
+      2147483679: The beginning of a tape or partition has been detected
+      2147483680: The media may have changed
+      2147483681: A tape access reached a set mark
+      2147483682: During a tape access, the end of the data written is reached
+      2147483683: The redirector is in use and cannot be unloaded
+      2147483684: The server is in use and cannot be unloaded
+      2147483685: The specified connection has already been disconnected
+      2147483686: A long jump has been executed
+      2147483687: A cleaner cartridge is present in the tape library
+      2147483688: The Plug and Play query operation was not successful
+      2147483689: A frame consolidation has been executed
+      2147483690: Registry Hive Recovered
+      2147483693: The create operation stopped after reaching a symbolic link
+      2147484296: The device has indicated that cleaning is necessary
+      2147484297: The device has indicated that its door is open. Further operations require it closed and secured
+      2148728833: The cluster node is already up
+      2148728834: The cluster node is already down
+      2148728835: The cluster network is already online
+      2148728836: The cluster network is already offline
+      2148728837: The cluster node is already a member of the cluster
+      2149122057: The log could not be set to the requested size
+      2149122089: There is no transaction metadata on the file
+      2149122097: The file cannot be recovered because there is a handle still open on it
+      2149122113: Transaction metadata is already present on this file and cannot be superseded
+      2149122114: A transaction scope could not be entered because the scope handler has not been initialized
+      2149253355: The display driver has stopped working normally. The recovery had been performed
+      2149318657: The buffer is too small to contain the entry. No information has been written to the buffer
+      2149646337: Volume metadata read or write is incomplete
+      2149646338: BitLocker encryption keys were ignored because the volume was in a transient state
+      3221225473: The requested operation was unsuccessful
+      3221225474: The requested operation is not implemented
+      3221225475: The specified information class is not a valid information class for the specified object
+      3221225476: The specified information record length does not match the length that is required for the specified information class
+      3221225477: The instruction at 0x%08lx referenced memory at 0x%08lx. The memory could not be %s
+      3221225478: The instruction at 0x%08lx referenced memory at 0x%08lx. The required data was not placed into memory because of an I/O error status of 0x%08lx
+      3221225479: The page file quota for the process has been exhausted
+      3221225480: An invalid HANDLE was specified
+      3221225481: An invalid initial stack was specified in a call to NtCreateThread
+      3221225482: An invalid initial start address was specified in a call to NtCreateThread
+      3221225483: An invalid client ID was specified
+      3221225484: An attempt was made to cancel or set a timer that has an associated APC and the specified thread is not the thread that originally set the timer with an associated APC routine
+      3221225485: An invalid parameter was passed to a service or function
+      3221225486: A device that does not exist was specified
+      3221225487: The file does not exist
+      3221225488: The specified request is not a valid operation for the target device
+      3221225489: The end-of-file marker has been reached. There is no valid data in the file beyond this marker
+      3221225490: The wrong volume is in the drive
+      3221225491: There is no disk in the drive
+      3221225492: The disk in drive is not formatted properly
+      3221225493: The specified sector does not exist
+      3221225494: The specified I/O request packet (IRP) cannot be disposed of because the I/O operation is not complete
+      3221225495: Not enough virtual memory or paging file quota is available to complete the specified operation
+      3221225496: The specified address range conflicts with the address space
+      3221225497: The address range to unmap is not a mapped view
+      3221225498: The virtual memory cannot be freed
+      3221225499: The specified section cannot be deleted
+      3221225500: An invalid system service was specified in a system service call
+      3221225501: Illegal Instruction An attempt was made to execute an illegal instruction
+      3221225502: An attempt was made to execute an invalid lock sequence
+      3221225503: An attempt was made to create a view for a section that is bigger than the section
+      3221225504: The attributes of the specified mapping file for a section of memory cannot be read
+      3221225505: The specified address range is already committed
+      3221225506: A process has requested access to an object but has not been granted those access rights
+      3221225507: The buffer is too small to contain the entry. No information has been written to the buffer
+      3221225508: There is a mismatch between the type of object that is required by the requested operation and the type of object that is specified in the request
+      3221225509: Cannot Continue Windows cannot continue from this exception
+      3221225510: An invalid exception disposition was returned by an exception handler
+      3221225511: Unwind exception code
+      3221225512: An invalid or unaligned stack was encountered during an unwind operation
+      3221225513: An invalid unwind target was encountered during an unwind operation
+      3221225514: An attempt was made to unlock a page of memory that was not locked
+      3221225515: A device parity error on an I/O operation
+      3221225516: An attempt was made to decommit uncommitted virtual memory
+      3221225517: An attempt was made to change the attributes on memory that has not been committed
+      3221225518: Invalid object attributes specified to NtCreatePort or invalid port attributes specified to NtConnectPort
+      3221225519: The length of the message that was passed to NtRequestPort or NtRequestWaitReplyPort is longer than the maximum message that is allowed by the port
+      3221225520: An invalid combination of parameters was specified
+      3221225521: An attempt was made to lower a quota limit below the current usage
+      3221225522: The file system structure on the disk is corrupt and unusable
+      3221225523: The object name is invalid
+      3221225524: The object name is not found
+      3221225525: The object name already exists
+      3221225527: An attempt was made to send a message to a disconnected communication port
+      3221225528: An attempt was made to attach to a device that was already attached to another device
+      3221225529: The object path component was not a directory object
+      3221225530: The path does not exist
+      3221225531: The object path component was not a directory object
+      3221225532: A data overrun error occurred
+      3221225533: A data late error occurred
+      3221225534: An error occurred in reading or writing data
+      3221225535: A cyclic redundancy check (CRC) checksum error occurred
+      3221225536: The specified section is too big to map the file
+      3221225537: The NtConnectPort request is refused
+      3221225538: The type of port handle is invalid for the operation that is requested
+      3221225539: A file cannot be opened because the share access flags are incompatible
+      3221225540: Insufficient quota exists to complete the operation
+      3221225541: The specified page protection was not valid
+      3221225542: An attempt to release a mutant object was made by a thread that was not the owner of the mutant object
+      3221225543: An attempt was made to release a semaphore such that its maximum count would have been exceeded
+      3221225544: An attempt was made to set the DebugPort or ExceptionPort of a process, but a port already exists in the process, or an attempt was made to set the CompletionPort of a file but a port was already set in the file, or an attempt was made to set the associated completion port of an ALPC port but it is already set
+      3221225545: An attempt was made to query image information on a section that does not map an image
+      3221225546: An attempt was made to suspend a thread whose suspend count was at its maximum
+      3221225547: An attempt was made to suspend a thread that has begun termination
+      3221225548: An attempt was made to set the working set limit to an invalid value (for example, the minimum greater than maximum)
+      3221225549: A section was created to map a file that is not compatible with an already existing section that maps the same file
+      3221225550: A view to a section specifies a protection that is incompatible with the protection of the initial view
+      3221225551: An operation involving EAs failed because the file system does not support EAs
+      3221225552: An EA operation failed because the EA set is too large
+      3221225553: An EA operation failed because the name or EA index is invalid
+      3221225554: The file for which EAs were requested has no EAs
+      3221225555: The EA is corrupt and cannot be read
+      3221225556: A requested read/write cannot be granted due to a conflicting file lock
+      3221225557: A requested file lock cannot be granted due to other existing locks
+      3221225558: A non-close operation has been requested of a file object that has a delete pending
+      3221225559: An attempt was made to set the control attribute on a file. This attribute is not supported in the destination file system
+      3221225560: Indicates a revision number that was encountered or specified is not one that is known by the service. It may be a more recent revision than the service is aware of
+      3221225561: Indicates that two revision levels are incompatible
+      3221225562: Indicates a particular security ID may not be assigned as the owner of an object
+      3221225563: Indicates a particular security ID may not be assigned as the primary group of an object
+      3221225564: An attempt has been made to operate on an impersonation token by a thread that is not currently impersonating a client
+      3221225565: A mandatory group may not be disabled
+      3221225566: No logon servers are currently available to service the logon request
+      3221225567: A specified logon session does not exist. It may already have been terminated
+      3221225568: A specified privilege does not exist
+      3221225569: A required privilege is not held by the client
+      3221225570: The name provided is not a properly formed account name
+      3221225571: The specified account already exists
+      3221225572: The specified account does not exist
+      3221225573: The specified group already exists
+      3221225574: The specified group does not exist
+      3221225575: The specified user account is already in the specified group account. Also used to indicate a group cannot be deleted because it contains a member
+      3221225576: The specified user account is not a member of the specified group account
+      3221225577: Indicates the requested operation would disable or delete the last remaining administration account. This is not allowed to prevent creating a situation in which the system cannot be administrated
+      3221225578: When trying to update a password, this return status indicates that the value provided as the current password is not correct
+      3221225579: When trying to update a password, this return status indicates that the value provided for the new password contains values that are not allowed in passwords
+      3221225580: When trying to update a password, this status indicates that some password update rule has been violated. For example, the password may not meet length criteria
+      3221225581: The attempted logon is invalid. This is either due to a bad username or authentication information
+      3221225582: Indicates a referenced user name and authentication information are valid, but some user account restriction has prevented successful authentication (such as time-of-day restrictions)
+      3221225583: The user account has time restrictions and may not be logged onto at this time
+      3221225584: The user account is restricted so that it may not be used to log on from the source workstation
+      3221225585: The user account password has expired
+      3221225586: The referenced account is currently disabled and may not be logged on to
+      3221225587: None of the information to be translated has been translated
+      3221225588: The number of LUIDs requested may not be allocated with a single allocation
+      3221225589: Indicates there are no more LUIDs to allocate
+      3221225590: Indicates the sub-authority value is invalid for the particular use
+      3221225591: Indicates the ACL structure is not valid
+      3221225592: Indicates the SID structure is not valid
+      3221225593: Indicates the SECURITY_DESCRIPTOR structure is not valid
+      3221225594: Indicates the specified procedure address cannot be found in the DLL
+      3221225596: An attempt was made to reference a token that does not exist. This is typically done by referencing the token that is associated with a thread when the thread is not impersonating a client
+      3221225597: Indicates that an attempt to build either an inherited ACL or ACE was not successful. This can be caused by a number of things. One of the more probable causes is the replacement of a CreatorId with a SID that did not fit into the ACE or ACL
+      3221225598: The range specified in NtUnlockFile was not locked
+      3221225599: An operation failed because the disk was full
+      3221225600: The GUID allocation server is disabled at the moment
+      3221225601: The GUID allocation server is enabled at the moment
+      3221225602: Too many GUIDs were requested from the allocation server at once
+      3221225603: The GUIDs could not be allocated because the Authority Agent was exhausted
+      3221225604: The value provided was an invalid value for an identifier authority
+      3221225605: No more authority agent values are available for the particular identifier authority value
+      3221225606: An invalid volume label has been specified
+      3221225607: A mapped section could not be extended
+      3221225608: Specified section to flush does not map a data file
+      3221225609: Indicates the specified image file did not contain a resource section
+      3221225610: Indicates the specified resource type cannot be found in the image file
+      3221225611: Indicates the specified resource name cannot be found in the image file
+      3221225612: Array bounds exceeded
+      3221225613: Floating-point denormal operand
+      3221225614: Floating-point division by zero
+      3221225615: Floating-point inexact result
+      3221225616: Floating-point invalid operation
+      3221225617: Floating-point overflow
+      3221225618: Floating-point stack check
+      3221225619: Floating-point underflow
+      3221225620: Integer division by zero
+      3221225621: Integer overflow
+      3221225622: Privileged instruction
+      3221225623: An attempt was made to install more paging files than the system supports
+      3221225624: The volume for a file has been externally altered such that the opened file is no longer valid
+      3221225625: When a block of memory is allotted for future updates, such as the memory allocated to hold discretionary access control and primary group information, successive updates may exceed the amount of memory originally allotted. Because a quota may already have been charged to several processes that have handles to the object, it is not reasonable to alter the size of the allocated memory. Instead, a request that requires more memory than has been allotted must fail and the STATUS_ALLOTTED_SPACE_EXCEEDED error returned
+      3221225626: Insufficient system resources exist to complete the API
+      3221225627: An attempt has been made to open a DFS exit path control file
+      3221225628: There are bad blocks (sectors) on the hard disk
+      3221225629: There is bad cabling, non-termination, or the controller is not able to obtain access to the hard disk
+      3221225631: Virtual memory cannot be freed because the base address is not the base of the region and a region size of zero was specified
+      3221225632: An attempt was made to free virtual memory that is not allocated
+      3221225633: The working set is not big enough to allow the requested pages to be locked
+      3221225634: The disk cannot be written to because it is write-protected
+      3221225635: The drive is not ready for use; its door may be open
+      3221225636: The specified attributes are invalid or are incompatible with the attributes for the group as a whole
+      3221225637: A specified impersonation level is invalid. Also used to indicate that a required impersonation level was not provided
+      3221225638: An attempt was made to open an anonymous-level token. Anonymous tokens may not be opened
+      3221225639: The validation information class requested was invalid
+      3221225640: The type of a token object is inappropriate for its attempted use
+      3221225641: The type of a token object is inappropriate for its attempted use
+      3221225642: An attempt was made to execute an instruction at an unaligned address and the host system does not support unaligned instruction references
+      3221225643: The maximum named pipe instance count has been reached
+      3221225644: An instance of a named pipe cannot be found in the listening state
+      3221225645: The named pipe is not in the connected or closing state
+      3221225646: The specified pipe is set to complete operations and there are current I/O operations queued so that it cannot be changed to queue operations
+      3221225647: The specified handle is not open to the server end of the named pipe
+      3221225648: The specified named pipe is in the disconnected state
+      3221225649: The specified named pipe is in the closing state
+      3221225650: The specified named pipe is in the connected state
+      3221225651: The specified named pipe is in the listening state
+      3221225652: The specified named pipe is not in message mode
+      3221225654: The specified file has been closed by another process
+      3221225655: Profiling is not started
+      3221225656: Profiling is not stopped
+      3221225657: The passed ACL did not contain the minimum required information
+      3221225658: The file that was specified as a target is a directory, and the caller specified that it could be anything but a directory
+      3221225659: The request is not supported
+      3221225660: This remote computer is not listening
+      3221225661: A duplicate name exists on the network
+      3221225662: The network path cannot be located
+      3221225663: The network is busy
+      3221225664: This device does not exist
+      3221225665: The network BIOS command limit has been reached
+      3221225666: An I/O adapter hardware error has occurred
+      3221225667: The network responded incorrectly
+      3221225668: An unexpected network error occurred
+      3221225669: The remote adapter is not compatible
+      3221225670: The print queue is full
+      3221225671: Space to store the file that is waiting to be printed is not available on the server
+      3221225672: The requested print file has been canceled
+      3221225673: The network name was deleted
+      3221225674: Network access is denied
+      3221225675: The specified device type (LPT, for example) conflicts with the actual device type on the remote resource
+      3221225676: The specified share name cannot be found on the remote server
+      3221225677: The name limit for the network adapter card of the local computer was exceeded
+      3221225678: The network BIOS session limit was exceeded
+      3221225679: File sharing has been temporarily paused
+      3221225680: No more connections can be made to this remote computer at this time because the computer has already accepted the maximum number of connections
+      3221225681: Print or disk redirection is temporarily paused
+      3221225682: A network data fault occurred
+      3221225683: The number of active profiling objects is at the maximum and no more may be started
+      3221225684: The destination file of a rename request is located on a different device than the source of the rename request
+      3221225685: The specified file has been renamed and thus cannot be modified
+      3221225686: The session with a remote server has been disconnected because the time-out interval for a request has expired
+      3221225687: Indicates an attempt was made to operate on the security of an object that does not have security associated with it
+      3221225688: Used to indicate that an operation cannot continue without blocking for I/O
+      3221225689: Used to indicate that a read operation was done on an empty pipe
+      3221225690: Configuration information could not be read from the domain controller, either because the machine is unavailable or access has been denied
+      3221225691: Indicates that a thread attempted to terminate itself by default (called NtTerminateThread with NULL) and it was the last thread in the current process
+      3221225692: Indicates the Sam Server was in the wrong state to perform the desired operation
+      3221225693: Indicates the domain was in the wrong state to perform the desired operation
+      3221225694: This operation is only allowed for the primary domain controller of the domain
+      3221225695: The specified domain did not exist
+      3221225696: The specified domain already exists
+      3221225697: An attempt was made to exceed the limit on the number of domains per server for this release
+      3221225698: An error status returned when the opportunistic lock (oplock) request is denied
+      3221225699: An error status returned when an invalid opportunistic lock (oplock) acknowledgment is received by a file system
+      3221225700: This error indicates that the requested operation cannot be completed due to a catastrophic media failure or an on-disk data structure corruption
+      3221225701: An internal error occurred
+      3221225702: Indicates generic access types were contained in an access mask which should already be mapped to non-generic access types
+      3221225703: Indicates a security descriptor is not in the necessary format (absolute or self-relative)
+      3221225704: An access to a user buffer failed at an expected point in time. This code is defined because the caller does not want to accept STATUS_ACCESS_VIOLATION in its filter
+      3221225705: If an I/O error that is not defined in the standard FsRtl filter is returned, it is converted to the following error, which is guaranteed to be in the filter. In this case, information is lost; however, the filter correctly handles the exception
+      3221225706: If an MM error that is not defined in the standard FsRtl filter is returned, it is converted to one of the following errors, which are guaranteed to be in the filter. In this case, information is lost; however, the filter correctly handles the exception
+      3221225707: If an MM error that is not defined in the standard FsRtl filter is returned, it is converted to one of the following errors, which are guaranteed to be in the filter. In this case, information is lost; however, the filter correctly handles the exception
+      3221225708: If an MM error that is not defined in the standard FsRtl filter is returned, it is converted to one of the following errors, which are guaranteed to be in the filter. In this case, information is lost; however, the filter correctly handles the exception
+      3221225709: The requested action is restricted for use by logon processes only. The calling process has not registered as a logon process
+      3221225710: An attempt has been made to start a new session manager or LSA logon session by using an ID that is already in use
+      3221225711: An invalid parameter was passed to a service or function as the first argument
+      3221225712: An invalid parameter was passed to a service or function as the second argument
+      3221225713: An invalid parameter was passed to a service or function as the third argument
+      3221225714: An invalid parameter was passed to a service or function as the fourth argument
+      3221225715: An invalid parameter was passed to a service or function as the fifth argument
+      3221225716: An invalid parameter was passed to a service or function as the sixth argument
+      3221225717: An invalid parameter was passed to a service or function as the seventh argument
+      3221225718: An invalid parameter was passed to a service or function as the eighth argument
+      3221225719: An invalid parameter was passed to a service or function as the ninth argument
+      3221225720: An invalid parameter was passed to a service or function as the tenth argument
+      3221225721: An invalid parameter was passed to a service or function as the eleventh argument
+      3221225722: An invalid parameter was passed to a service or function as the twelfth argument
+      3221225723: An attempt was made to access a network file, but the network software was not yet started
+      3221225724: An attempt was made to start the redirector, but the redirector has already been started
+      3221225725: A new guard page for the stack cannot be created
+      3221225726: A specified authentication package is unknown
+      3221225727: A malformed function table was encountered during an unwind operation
+      3221225728: Indicates the specified environment variable name was not found in the specified environment block
+      3221225729: Indicates that the directory trying to be deleted is not empty
+      3221225730: The file or directory is corrupt and unreadable
+      3221225731: A requested opened file is not a directory
+      3221225732: The logon session is not in a state that is consistent with the requested operation
+      3221225733: An internal LSA error has occurred. An authentication package has requested the creation of a logon session but the ID of an already existing logon session has been specified
+      3221225734: A specified name string is too long for its intended use
+      3221225735: The user attempted to force close the files on a redirected drive, but there were opened files on the drive, and the user did not specify a sufficient level of force
+      3221225736: The user attempted to force close the files on a redirected drive, but there were opened directories on the drive, and the user did not specify a sufficient level of force
+      3221225737: RtlFindMessage could not locate the requested message ID in the message table resource
+      3221225738: An attempt was made to duplicate an object handle into or out of an exiting process
+      3221225739: Indicates an invalid value has been provided for the LogonType requested
+      3221225740: Indicates that an attempt was made to assign protection to a file system file or directory and one of the SIDs in the security descriptor could not be translated into a GUID that could be stored by the file system. This causes the protection attempt to fail, which may cause a file creation attempt to fail
+      3221225741: Indicates that an attempt has been made to impersonate via a named pipe that has not yet been read from
+      3221225742: Indicates that the specified image is already loaded
+      3221225751: Indicates that an attempt was made to change the size of the LDT for a process that has no LDT
+      3221225752: Indicates that an attempt was made to grow an LDT by setting its size, or that the size was not an even number of selectors
+      3221225753: Indicates that the starting value for the LDT information was not an integral multiple of the selector size
+      3221225754: Indicates that the user supplied an invalid descriptor when trying to set up LDT descriptors
+      3221225755: The specified image file did not have the correct format. It appears to be NE format
+      3221225756: Indicates that the transaction state of a registry subtree is incompatible with the requested operation. For example, a request has been made to start a new transaction with one already in progress, or a request has been made to apply a transaction when one is not currently in progress
+      3221225757: Indicates an error has occurred during a registry transaction commit. The database has been left in an unknown, but probably inconsistent, state. The state of the registry transaction is left as COMMITTING
+      3221225758: An attempt was made to map a file of size zero with the maximum size specified as zero
+      3221225759: Too many files are opened on a remote server. This error should only be returned by the Windows redirector on a remote drive
+      3221225760: The I/O request was canceled
+      3221225761: An attempt has been made to remove a file or directory that cannot be deleted
+      3221225762: Indicates a name that was specified as a remote computer name is syntactically invalid
+      3221225763: An I/O request other than close was performed on a file after it was deleted, which can only happen to a request that did not complete before the last handle was closed via NtClose
+      3221225764: Indicates an operation that is incompatible with built-in accounts has been attempted on a built-in (special) SAM account. For example, built-in accounts cannot be deleted
+      3221225765: The operation requested may not be performed on the specified group because it is a built-in special group
+      3221225766: The operation requested may not be performed on the specified user because it is a built-in special user
+      3221225767: Indicates a member cannot be removed from a group because the group is currently the member's primary group
+      3221225768: An I/O request other than close and several other special case operations was attempted using a file object that had already been closed
+      3221225769: Indicates a process has too many threads to perform the requested action. For example, assignment of a primary token may only be performed when a process has zero or one threads
+      3221225770: An attempt was made to operate on a thread within a specific process, but the specified thread is not in the specified process
+      3221225771: An attempt was made to establish a token for use as a primary token but the token is already in use. A token can only be the primary token of one process at a time
+      3221225772: The page file quota was exceeded
+      3221225773: Your system is low on virtual memory. To ensure that Windows runs correctly, increase the size of your virtual memory paging file. For more information, see Help
+      3221225774: The specified image file did not have the correct format
+      3221225775: The specified image file did not have the correct format
+      3221225776: The specified image file did not have the correct format
+      3221225777: The specified image file did not have the correct format
+      3221225779: The time at the primary domain controller is different from the time at the backup domain controller or member server by too large an amount
+      3221225780: The SAM database on a Windows Server is significantly out of synchronization with the copy on the domain controller. A complete synchronization is required
+      3221225781: This application has failed to start
+      3221225782: The NtCreateFile API failed. This error should never be returned to an application; it is a place holder for the Windows LAN Manager Redirector to use in its internal error-mapping routines
+      3221225783: The I/O permissions for the process could not be changed
+      3221225785: The procedure entry point could not be located in the dynamic link library
+      3221225786: The application terminated as a result of a CTRL+C
+      3221225787: The network transport on your computer has closed a network connection. There may or may not be I/O requests outstanding
+      3221225788: The network transport on a remote computer has closed a network connection. There may or may not be I/O requests outstanding
+      3221225789: The remote computer has insufficient resources to complete the network request. For example, the remote computer may not have enough available memory to carry out the request at this time
+      3221225790: An existing connection (virtual circuit) has been broken at the remote computer. There is probably something wrong with the network software protocol or the network hardware on the remote computer
+      3221225791: The network transport on your computer has closed a network connection because it had to wait too long for a response from the remote computer
+      3221225792: The connection handle that was given to the transport was invalid
+      3221225793: The address handle that was given to the transport was invalid
+      3221225794: Initialization of the dynamic link library failed. The process is terminating abnormally
+      3221225795: The required system file is bad or missing
+      3221225796: The exception %s (0x%08lx) occurred in the application at location 0x%08lx
+      3221225797: The application failed to initialize properly (0x%lx). Click OK to terminate the application
+      3221225798: The creation of the paging file failed
+      3221225799: No paging file was specified in the system configuration
+      3221225800: An invalid level was passed into the specified system call
+      3221225801: You specified an incorrect password to a LAN Manager 2.x or MS-NET server
+      3221225802: A real-mode application issued a floating-point instruction and floating-point hardware is not present
+      3221225803: The pipe operation has failed because the other end of the pipe has been closed
+      3221225804: The structure of one of the files that contains registry data is corrupt; the image of the file in memory is corrupt; or the file could not be recovered because the alternate copy or log was absent or corrupt
+      3221225805: An I/O operation initiated by the Registry failed and cannot be recovered. The registry could not read in, write out, or flush one of the files that contain the system's image of the registry
+      3221225806: An event pair synchronization operation was performed using the thread-specific client/server event pair object, but no event pair object was associated with the thread
+      3221225807: The volume does not contain a recognized file system. Be sure that all required file system drivers are loaded and that the volume is not corrupt
+      3221225808: No serial device was successfully initialized. The serial driver will unload
+      3221225809: The specified local group does not exist
+      3221225810: The specified account name is not a member of the group
+      3221225811: The specified account name is already a member of the group
+      3221225812: The specified local group already exists
+      3221225813: A requested type of logon (for example, interactive, network, and service) is not granted by the local security policy of the target system. Ask the system administrator to grant the necessary form of logon
+      3221225814: The maximum number of secrets that may be stored in a single system was exceeded. The length and number of secrets is limited to satisfy U.S. State Department export restrictions
+      3221225815: The length of a secret exceeds the maximum allowable length. The length and number of secrets is limited to satisfy U.S. State Department export restrictions
+      3221225816: The local security authority (LSA) database contains an internal inconsistency
+      3221225817: The requested operation cannot be performed in full-screen mode
+      3221225818: During a logon attempt, the user's security context accumulated too many security IDs. This is a very unusual situation. Remove the user from some global or local groups to reduce the number of security IDs to incorporate into the security context
+      3221225819: A user has requested a type of logon (for example, interactive or network) that has not been granted. An administrator has control over who may logon interactively and through the network
+      3221225820: The system has attempted to load or restore a file into the registry, and the specified file is not in the format of a registry file
+      3221225821: An attempt was made to change a user password in the security account manager without providing the necessary Windows cross-encrypted password
+      3221225822: A Windows Server has an incorrect configuration
+      3221225823: An attempt was made to explicitly access the secondary copy of information via a device control to the fault tolerance driver and the secondary copy is not present in the system
+      3221225824: A configuration registry node that represents a driver service entry was ill-formed and did not contain the required value entries
+      3221225825: An illegal character was encountered. For a multibyte character set, this includes a lead byte without a succeeding trail byte. For the Unicode character set this includes the characters 0xFFFF and 0xFFFE
+      3221225826: No mapping for the Unicode character exists in the target multibyte code page
+      3221225827: The Unicode character is not defined in the Unicode character set that is installed on the system
+      3221225828: The paging file cannot be created on a floppy disk
+      3221225829: While accessing a floppy disk, an ID address mark was not found
+      3221225830: While accessing a floppy disk, the track address from the sector ID field was found to be different from the track address that is maintained by the controller
+      3221225831: The floppy disk controller reported an error that is not recognized by the floppy disk driver
+      3221225832: While accessing a floppy-disk, the controller returned inconsistent results via its registers
+      3221225833: While accessing the hard disk, a recalibrate operation failed, even after retries
+      3221225834: While accessing the hard disk, a disk operation failed even after retries
+      3221225835: While accessing the hard disk, a disk controller reset was needed, but even that failed
+      3221225836: An attempt was made to open a device that was sharing an interrupt request (IRQ) with other devices. At least one other device that uses that IRQ was already opened. Two concurrent opens of devices that share an IRQ and only work via interrupts is not supported for the particular bus type that the devices use
+      3221225837: A disk that is part of a fault-tolerant volume can no longer be accessed
+      3221225838: The basic input/output system (BIOS) failed to connect a system interrupt to the device or bus for which the device is connected
+      3221225842: The tape could not be partitioned
+      3221225843: When accessing a new tape of a multi-volume partition, the current blocksize is incorrect
+      3221225844: The tape partition information could not be found when loading a tape
+      3221225845: An attempt to lock the eject media mechanism failed
+      3221225846: An attempt to unload media failed
+      3221225847: The physical end of tape was detected
+      3221225848: There is no media in the drive
+      3221225850: A member could not be added to or removed from the local group because the member does not exist
+      3221225851: A new member could not be added to a local group because the member has the wrong account type
+      3221225852: An illegal operation was attempted on a registry key that has been marked for deletion
+      3221225853: The system could not allocate the required space in a registry log
+      3221225854: Too many SIDs have been specified
+      3221225855: An attempt was made to change a user password in the security account manager without providing the necessary LM cross-encrypted password
+      3221225856: An attempt was made to create a symbolic link in a registry key that already has subkeys or values
+      3221225857: An attempt was made to create a stable subkey under a volatile parent key
+      3221225858: The I/O device is configured incorrectly or the configuration parameters to the driver are incorrect
+      3221225859: An error was detected between two drivers or within an I/O driver
+      3221225860: The device is not in a valid state to perform this request
+      3221225861: The I/O device reported an I/O error
+      3221225862: A protocol error was detected between the driver and the device
+      3221225863: This operation is only allowed for the primary domain controller of the domain
+      3221225864: The log file space is insufficient to support this operation
+      3221225865: A write operation was attempted to a volume after it was dismounted
+      3221225866: The workstation does not have a trust secret for the primary domain in the local LSA database
+      3221225867: The SAM database on the Windows Server does not have a computer account for this workstation trust relationship
+      3221225868: The logon request failed because the trust relationship between the primary domain and the trusted domain failed
+      3221225869: The logon request failed because the trust relationship between this workstation and the primary domain failed
+      3221225870: The Eventlog log file is corrupt
+      3221225871: No Eventlog log file could be opened. The Eventlog service did not start
+      3221225872: The network logon failed. This may be because the validation authority cannot be reached
+      3221225873: An attempt was made to acquire a mutant such that its maximum count would have been exceeded
+      3221225874: An attempt was made to logon, but the NetLogon service was not started
+      3221225875: The user account has expired
+      3221225876: Possible deadlock condition
+      3221225877: Multiple connections to a server or shared resource by the same user, using more than one user name, are not allowed. Disconnect all previous connections to the server or shared resource and try again
+      3221225878: An attempt was made to establish a session to a network server, but there are already too many sessions established to that server
+      3221225879: The log file has changed between reads
+      3221225880: The account used is an interdomain trust account. Use your global user account or local user account to access this server
+      3221225881: The account used is a computer account. Use your global user account or local user account to access this server
+      3221225882: The account used is a server trust account. Use your global user account or local user account to access this server
+      3221225883: The name or SID of the specified domain is inconsistent with the trust information for that domain
+      3221225884: A volume has been accessed for which a file system driver is required that has not yet been loaded
+      3221225885: Indicates that the specified image is already loaded as a DLL
+      3221225886: Short name settings may not be changed on this volume due to the global registry setting
+      3221225887: Short names are not enabled on this volume
+      3221225888: The security stream for the given volume is in an inconsistent state. Please run CHKDSK on the volume
+      3221225889: A requested file lock operation cannot be processed due to an invalid byte range
+      3221225890: The specified access control entry (ACE) contains an invalid condition
+      3221225891: The subsystem needed to support the image type is not present
+      3221225892: The specified file already has a notification GUID associated with it
+      3221225985: A remote open failed because the network open restrictions were not satisfied
+      3221225986: There is no user session key for the specified logon session
+      3221225987: The remote user session has been deleted
+      3221225988: Indicates the specified resource language ID cannot be found in the image file
+      3221225989: Insufficient server resources exist to complete the request
+      3221225990: The size of the buffer is invalid for the specified operation
+      3221225991: The transport rejected the specified network address as invalid
+      3221225992: The transport rejected the specified network address due to invalid use of a wildcard
+      3221225993: The transport address could not be opened because all the available addresses are in use
+      3221225994: The transport address could not be opened because it already exists
+      3221225995: The transport address is now closed
+      3221225996: The transport connection is now disconnected
+      3221225997: The transport connection has been reset
+      3221225998: The transport cannot dynamically acquire any more nodes
+      3221225999: The transport aborted a pending transaction
+      3221226000: The transport timed out a request that is waiting for a response
+      3221226001: The transport did not receive a release for a pending response
+      3221226002: The transport did not find a transaction that matches the specific token
+      3221226003: The transport had previously responded to a transaction request
+      3221226004: The transport does not recognize the specified transaction request ID
+      3221226005: The transport does not recognize the specified transaction request type
+      3221226006: The transport can only process the specified request on the server side of a session
+      3221226007: The transport can only process the specified request on the client side of a session
+      3221226008: The registry cannot load the hive (file)
+      3221226009: An unexpected failure occurred while processing a DebugActiveProcess API request. You may choose OK to terminate the process, or Cancel to ignore the error
+      3221226010: The system process terminated unexpectedly
+      3221226011: The TDI client could not handle the data received during an indication
+      3221226012: The list of servers for this workgroup is not currently available
+      3221226013: NTVDM encountered a hard error
+      3221226014: The driver failed to complete a canceled I/O request in the allotted time
+      3221226015: An attempt was made to reply to an LPC message, but the thread specified by the client ID in the message was not waiting on that message
+      3221226016: An attempt was made to map a view of a file, but either the specified base address or the offset into the file were not aligned on the proper allocation granularity
+      3221226017: The image is possibly corrupt. The header checksum does not match the computed checksum
+      3221226018: Windows was unable to save all the data for the file
+      3221226019: The parameters passed to the server in the client/server shared memory window were invalid. Too much data may have been put in the shared memory window
+      3221226020: The user password must be changed before logging on the first time
+      3221226021: The object was not found
+      3221226022: The stream is not a tiny stream
+      3221226023: A transaction recovery failed
+      3221226024: The request must be handled by the stack overflow code
+      3221226025: A consistency check failed
+      3221226026: The attempt to insert the ID in the index failed because the ID is already in the index
+      3221226027: The attempt to set the object ID failed because the object already has an ID
+      3221226028: Internal OFS status codes indicating how an allocation operation is handled. Either it is retried after the containing oNode is moved or the extent stream is converted to a large stream
+      3221226029: The request needs to be retried
+      3221226030: The attempt to find the object found an object on the volume that matches by ID; however, it is out of the scope of the handle that is used for the operation
+      3221226031: The bucket array must be grown. Retry the transaction after doing so
+      3221226032: The specified property set does not exist on the object
+      3221226033: The user/kernel marshaling buffer has overflowed
+      3221226034: The supplied variant structure contains invalid data
+      3221226035: A domain controller for this domain was not found
+      3221226036: The user account has been automatically locked because too many invalid logon attempts or password change attempts have been requested
+      3221226037: NtClose was called on a handle that was protected from close via NtSetInformationObject
+      3221226038: The transport-connection attempt was refused by the remote system
+      3221226039: The transport connection was gracefully closed
+      3221226040: The transport endpoint already has an address associated with it
+      3221226041: An address has not yet been associated with the transport endpoint
+      3221226042: An operation was attempted on a nonexistent transport connection
+      3221226043: An invalid operation was attempted on an active transport connection
+      3221226044: The remote network is not reachable by the transport
+      3221226045: The remote system is not reachable by the transport
+      3221226046: The remote system does not support the transport protocol
+      3221226047: No service is operating at the destination port of the transport on the remote system
+      3221226048: The request was aborted
+      3221226049: The transport connection was aborted by the local system
+      3221226050: The specified buffer contains ill-formed data
+      3221226051: The requested operation cannot be performed on a file with a user mapped section open
+      3221226052: An attempt to generate a security audit failed
+      3221226053: The timer resolution was not previously set by the current process
+      3221226054: A connection to the server could not be made because the limit on the number of concurrent connections for this account has been reached
+      3221226055: Attempting to log on during an unauthorized time of day for this account
+      3221226056: The account is not authorized to log on from this station
+      3221226057: The image has been modified for use on a uniprocessor system, but you are running it on a multiprocessor machine. Reinstall the image file
+      3221226064: There is insufficient account information to log you on
+      3221226065: The dynamic link library is not written correctly
+      3221226066: The service is not written correctly
+      3221226067: The server received the messages but did not send a reply
+      3221226068: There is an IP address conflict with another system on the network
+      3221226069: There is an IP address conflict with another system on the network
+      3221226070: The system has reached the maximum size that is allowed for the system part of the registry. Additional storage requests will be ignored
+      3221226071: The contacted server does not support the indicated part of the DFS namespace
+      3221226072: A callback return system service cannot be executed when no callback is active
+      3221226073: The service being accessed is licensed for a particular number of connections. No more connections can be made to the service at this time because the service has already accepted the maximum number of connections
+      3221226074: The password provided is too short to meet the policy of your user account. Choose a longer password
+      3221226075: The policy of your user account does not allow you to change passwords too frequently. This is done to prevent users from changing back to a familiar, but potentially discovered, password. If you feel your password has been compromised, contact your administrator immediately to have a new one assigned
+      3221226076: You have attempted to change your password to one that you have used in the past. The policy of your user account does not allow this. Select a password that you have not previously used
+      3221226078: You have attempted to load a legacy device driver while its device instance had been disabled
+      3221226079: The specified compression format is unsupported
+      3221226080: The specified hardware profile configuration is invalid
+      3221226081: The specified Plug and Play registry device path is invalid
+      3221226082: The device driver could not locate the ordinal in driver
+      3221226083: The device driver could not locate the entry point in driver
+      3221226084: The application attempted to release a resource it did not own. Click OK to terminate the application
+      3221226085: An attempt was made to create more links on a file than the file system supports
+      3221226086: The specified quota list is internally inconsistent with its descriptor
+      3221226087: The specified file has been relocated to offline storage
+      3221226088: The evaluation period for this installation of Windows has expired. This system will shutdown in 1 hour. To restore access to this installation of Windows, upgrade this installation by using a licensed distribution of this product
+      3221226089: The system DLL was relocated in memory
+      3221226090: The system has detected tampering with your registered product type. This is a violation of your software license. Tampering with the product type is not permitted
+      3221226091: The application failed to initialize because the window station is shutting down
+      3221226092: device driver could not be loaded
+      3221226093: DFS is unavailable on the contacted server
+      3221226094: An operation was attempted to a volume after it was dismounted
+      3221226095: An internal error occurred in the Win32 x86 emulation subsystem
+      3221226096: Win32 x86 emulation subsystem floating-point stack check
+      3221226097: The validation process needs to continue on to the next step
+      3221226098: There was no match for the specified key in the index
+      3221226099: There are no more matches for the current index enumeration
+      3221226101: The NTFS file or directory is not a reparse point
+      3221226102: The Windows I/O reparse tag passed for the NTFS reparse point is invalid
+      3221226103: The Windows I/O reparse tag does not match the one that is in the NTFS reparse point
+      3221226104: The user data passed for the NTFS reparse point is invalid
+      3221226105: The layered file system driver for this I/O tag did not handle it when needed
+      3221226112: The NTFS symbolic link could not be resolved even though the initial file name is valid
+      3221226113: The NTFS directory is a reparse point
+      3221226114: The range could not be added to the range list because of a conflict
+      3221226115: The specified medium changer source element contains no media
+      3221226116: The specified medium changer destination element already contains media
+      3221226117: The specified medium changer element does not exist
+      3221226118: The specified element is contained in a magazine that is no longer present
+      3221226119: The device requires re-initialization due to hardware errors
+      3221226122: The file encryption attempt failed
+      3221226123: The file decryption attempt failed
+      3221226124: The specified range could not be found in the range list
+      3221226125: There is no encryption recovery policy configured for this system
+      3221226126: The required encryption driver is not loaded for this system
+      3221226127: The file was encrypted with a different encryption driver than is currently loaded
+      3221226128: There are no EFS keys defined for the user
+      3221226129: The specified file is not encrypted
+      3221226130: The specified file is not in the defined EFS export format
+      3221226131: The specified file is encrypted and the user does not have the ability to decrypt it
+      3221226133: The GUID passed was not recognized as valid by a WMI data provider
+      3221226134: The instance name passed was not recognized as valid by a WMI data provider
+      3221226135: The data item ID passed was not recognized as valid by a WMI data provider
+      3221226136: The WMI request could not be completed and should be retried
+      3221226137: The policy object is shared and can only be modified at the root
+      3221226138: The policy object does not exist when it should
+      3221226139: The requested policy information only lives in the Ds
+      3221226140: The volume must be upgraded to enable this feature
+      3221226141: The remote storage service is not operational at this time
+      3221226142: The remote storage service encountered a media error
+      3221226143: The tracking (workstation) service is not running
+      3221226144: The server process is running under a SID that is different from the SID that is required by client
+      3221226145: The specified directory service attribute or value does not exist
+      3221226146: The attribute syntax specified to the directory service is invalid
+      3221226147: The attribute type specified to the directory service is not defined
+      3221226148: The specified directory service attribute or value already exists
+      3221226149: The directory service is busy
+      3221226150: The directory service is unavailable
+      3221226151: The directory service was unable to allocate a relative identifier
+      3221226152: The directory service has exhausted the pool of relative identifiers
+      3221226153: The requested operation could not be performed because the directory service is not the master for that type of operation
+      3221226154: The directory service was unable to initialize the subsystem that allocates relative identifiers
+      3221226155: The requested operation did not satisfy one or more constraints that are associated with the class of the object
+      3221226156: The directory service can perform the requested operation only on a leaf object
+      3221226157: The directory service cannot perform the requested operation on the Relatively Defined Name (RDN) attribute of an object
+      3221226158: The directory service detected an attempt to modify the object class of an object
+      3221226159: An error occurred while performing a cross domain move operation
+      3221226160: Unable to contact the global catalog server
+      3221226161: The requested operation requires a directory service, and none was available
+      3221226162: The reparse attribute cannot be set because it is incompatible with an existing attribute
+      3221226163: A group marked "use for deny only" cannot be enabled
+      3221226164: Multiple floating-point faults
+      3221226165: Multiple floating-point traps
+      3221226166: The device has been removed
+      3221226167: The volume change journal is being deleted
+      3221226168: The volume change journal is not active
+      3221226169: The requested interface is not supported
+      3221226177: A directory service resource limit has been exceeded
+      3221226178: The driver does not support standby mode. Updating this driver may allow the system to go to standby mode
+      3221226179: Mutual Authentication failed. The server password is out of date at the domain controller
+      3221226180: The system file %1 has become corrupt and has been replaced
+      3221226181: Alignment Error A data type misalignment error was detected in a load or store instruction
+      3221226182: The WMI data item or data block is read-only
+      3221226183: The WMI data item or data block could not be changed
+      3221226184: Your system is low on virtual memory. Windows is increasing the size of your virtual memory paging file. During this process, memory requests for some applications may be denied. For more information, see Help
+      3221226185: Register NaT consumption faults. A NaT value is consumed on a non-speculative instruction
+      3221226186: The transport element of the medium changer contains media, which is causing the operation to fail
+      3221226187: Security Accounts Manager initialization failed because of the following error
+      3221226188: This operation is supported only when you are connected to the server
+      3221226189: Only an administrator can modify the membership list of an administrative group
+      3221226190: A device was removed so enumeration must be restarted
+      3221226191: The journal entry has been deleted from the journal
+      3221226192: Cannot change the primary group ID of a domain controller account
+      3221226193: The system image %s is not properly signed. The file has been replaced with the signed file. The system has been shut down
+      3221226194: The device will not start without a reboot
+      3221226195: The power state of the current device cannot support this request
+      3221226196: The specified group type is invalid
+      3221226197: In a mixed domain, no nesting of a global group if the group is security enabled
+      3221226198: In a mixed domain, cannot nest local groups with other local groups, if the group is security enabled
+      3221226199: A global group cannot have a local group as a member
+      3221226200: A global group cannot have a universal group as a member
+      3221226201: A universal group cannot have a local group as a member
+      3221226202: A global group cannot have a cross-domain member
+      3221226203: A local group cannot have another cross-domain local group as a member
+      3221226204: Cannot change to a security-disabled group because primary members are in this group
+      3221226205: The WMI operation is not supported by the data block or method
+      3221226206: There is not enough power to complete the requested operation
+      3221226207: The Security Accounts Manager needs to get the boot password
+      3221226208: The Security Accounts Manager needs to get the boot key from the floppy disk
+      3221226209: The directory service cannot start
+      3221226210: The directory service could not start because of the following error
+      3221226211: The Security Accounts Manager initialization failed because of the following error
+      3221226212: The requested operation can be performed only on a global catalog server
+      3221226213: A local group can only be a member of other local groups in the same domain
+      3221226214: Foreign security principals cannot be members of universal groups
+      3221226215: Your computer could not be joined to the domain. You have exceeded the maximum number of computer accounts you are allowed to create in this domain. Contact your system administrator to have this limit reset or increased
+      3221226217: This operation cannot be performed on the current domain
+      3221226218: The directory or file cannot be created
+      3221226219: The system is in the process of shutting down
+      3221226220: Directory Services could not start because of the following error
+      3221226221: Security Accounts Manager initialization failed because of the following error
+      3221226222: A security context was deleted before the context was completed. This is considered a logon failure
+      3221226223: The client is trying to negotiate a context and the server requires user-to-user but did not send a TGT reply
+      3221226224: An object ID was not found in the file
+      3221226225: Unable to accomplish the requested task because the local machine does not have any IP addresses
+      3221226226: The supplied credential handle does not match the credential that is associated with the security context
+      3221226227: The crypto system or checksum function is invalid because a required function is unavailable
+      3221226228: The number of maximum ticket referrals has been exceeded
+      3221226229: The local machine must be a Kerberos KDC (domain controller) and it is not
+      3221226230: The other end of the security negotiation requires strong crypto but it is not supported on the local machine
+      3221226231: The KDC reply contained more than one principal name
+      3221226232: Expected to find PA data for a hint of what etype to use, but it was not found
+      3221226233: The client certificate does not contain a valid UPN, or does not match the client name in the logon request. Contact your administrator
+      3221226234: Smart card logon is required and was not used
+      3221226235: An invalid request was sent to the KDC
+      3221226236: The KDC was unable to generate a referral for the service requested
+      3221226237: The encryption type requested is not supported by the KDC
+      3221226238: A system shutdown is in progress
+      3221226239: The server machine is shutting down
+      3221226240: This operation is not supported on a computer running Windows Server 2003 for Small Business Server
+      3221226241: The WMI GUID is no longer available
+      3221226242: Collection or events for the WMI GUID is already disabled
+      3221226243: Collection or events for the WMI GUID is already enabled
+      3221226244: The master file table on the volume is too fragmented to complete this operation
+      3221226245: Copy protection failure
+      3221226246: Copy protection error-DVD CSS Authentication failed
+      3221226247: Copy protection error-The specified sector does not contain a valid key
+      3221226248: Copy protection error-DVD session key not established
+      3221226249: Copy protection error-The read failed because the sector is encrypted
+      3221226250: Copy protection error-The region of the specified DVD does not correspond to the region setting of the drive
+      3221226251: Copy protection error-The region setting of the drive may be permanent
+      3221226272: The Kerberos protocol encountered an error while validating the KDC certificate during smart card logon. There is more information in the system event log
+      3221226273: The Kerberos protocol encountered an error while attempting to use the smart card subsystem
+      3221226274: The target server does not have acceptable Kerberos credentials
+      3221226320: The transport determined that the remote system is down
+      3221226321: An unsupported pre-authentication mechanism was presented to the Kerberos package
+      3221226322: The encryption algorithm that is used on the source file needs a bigger key buffer than the one that is used on the destination file
+      3221226323: An attempt to remove a processes DebugPort was made, but a port was not already associated with the process
+      3221226324: An attempt to do an operation on a debug port failed because the port is in the process of being deleted
+      3221226325: This version of Windows is not compatible with the behavior version of the directory forest, domain, or domain controller
+      3221226326: The specified event is currently not being audited
+      3221226327: The machine account was created prior to Windows NT 4.0. The account needs to be recreated
+      3221226328: An account group cannot have a universal group as a member
+      3221226329: The specified image file did not have the correct format; it appears to be a 32-bit Windows image
+      3221226330: The specified image file did not have the correct format; it appears to be a 64-bit Windows image
+      3221226331: The client's supplied SSPI channel bindings were incorrect
+      3221226332: The client session has expired; so the client must re-authenticate to continue accessing the remote resources
+      3221226333: The AppHelp dialog box canceled; thus preventing the application from starting
+      3221226334: The SID filtering operation removed all SIDs
+      3221226335: The driver was not loaded because the system is starting in safe mode
+      3221226337: Access to %1 has been restricted by your Administrator by the default software restriction policy level
+      3221226338: Access to %1 has been restricted by your Administrator by location with policy rule %2 placed on path %3
+      3221226339: Access to %1 has been restricted by your Administrator by software publisher policy
+      3221226340: Access to %1 has been restricted by your Administrator by policy rule %2
+      3221226341: The driver was not loaded because it failed its initialization call
+      3221226342: The device encountered an error while applying power or reading the device configuration. This may be caused by a failure of your hardware or by a poor connection
+      3221226344: The create operation failed because the name contained at least one mount point that resolves to a volume to which the specified device object is not attached
+      3221226345: The device object parameter is either not a valid device object or is not attached to the volume that is specified by the file name
+      3221226346: A machine check error has occurred. Check the system event log for additional information
+      3221226347: Driver %2 has been blocked from loading
+      3221226348: Driver %2 has been blocked from loading
+      3221226349: There was error [%2] processing the driver database
+      3221226350: System hive size has exceeded its limit
+      3221226351: A dynamic link library (DLL) referenced a module that was neither a DLL nor the process's executable image
+      3221226353: The local account store does not contain secret material for the specified account
+      3221226354: Access to %1 has been restricted by your Administrator by policy rule %2
+      3221226355: The system was not able to allocate enough memory to perform a stack switch
+      3221226356: A heap has been corrupted
+      3221226368: An incorrect PIN was presented to the smart card
+      3221226369: The smart card is blocked
+      3221226370: No PIN was presented to the smart card
+      3221226371: No smart card is available
+      3221226372: The requested key container does not exist on the smart card
+      3221226373: The requested certificate does not exist on the smart card
+      3221226374: The requested keyset does not exist
+      3221226375: A communication error with the smart card has been detected
+      3221226376: The system detected a possible attempt to compromise security. Ensure that you can contact the server that authenticated you
+      3221226377: The smart card certificate used for authentication has been revoked. Contact your system administrator. There may be additional information in the event log
+      3221226378: An untrusted certificate authority was detected while processing the smart card certificate that is used for authentication. Contact your system administrator
+      3221226379: The revocation status of the smart card certificate that is used for authentication could not be determined. Contact your system administrator
+      3221226380: The smart card certificate used for authentication was not trusted. Contact your system administrator
+      3221226381: The smart card certificate used for authentication has expired. Contact your system administrator
+      3221226382: The driver could not be loaded because a previous version of the driver is still in memory
+      3221226383: The smart card provider could not perform the action because the context was acquired as silent
+      3221226497: The delegated trust creation quota of the current user has been exceeded
+      3221226498: The total delegated trust creation quota has been exceeded
+      3221226499: The delegated trust deletion quota of the current user has been exceeded
+      3221226500: The requested name already exists as a unique identifier
+      3221226501: The requested object has a non-unique identifier and cannot be retrieved
+      3221226502: The group cannot be converted due to attribute restrictions on the requested group type
+      3221226503: Wait while the Volume Shadow Copy Service prepares volume for hibernation
+      3221226504: Kerberos sub-protocol User2User is required
+      3221226505: The system detected an overrun of a stack-based buffer in this application. This overrun could potentially allow a malicious user to gain control of this application
+      3221226506: The Kerberos subsystem encountered an error. A service for user protocol request was made against a domain controller which does not support service for user
+      3221226507: An attempt was made by this server to make a Kerberos constrained delegation request for a target that is outside the server realm. This action is not supported and the resulting error indicates a misconfiguration on the allowed-to-delegate-to list for this server. Contact your administrator
+      3221226508: The revocation status of the domain controller certificate used for smart card authentication could not be determined. There is additional information in the system event log. Contact your system administrator
+      3221226509: An untrusted certificate authority was detected while processing the domain controller certificate used for authentication. There is additional information in the system event log. Contact your system administrator
+      3221226510: The domain controller certificate used for smart card logon has expired. Contact your system administrator with the contents of your system event log
+      3221226511: The domain controller certificate used for smart card logon has been revoked. Contact your system administrator with the contents of your system event log
+      3221226512: Data present in one of the parameters is more than the function can operate on
+      3221226513: The system has failed to hibernate
+      3221226514: An attempt to delay-load a .dll or get a function address in a delay-loaded .dll failed
+      3221226515: Logon Failure - The machine you are logging onto is protected by an authentication firewall. The specified account is not allowed to authenticate to the machine
+      3221226516: 16-bit application. You do not have permissions to execute 16-bit applications. Check your permissions with your system administrator
+      3221226517: The display driver has stopped working normally
+      3221226518: The Desktop heap encountered an error while allocating session memory. There is more information in the system event log
+      3221226519: An invalid parameter was passed to a C runtime function
+      3221226520: The authentication failed because NTLM was blocked
+      3221226521: The source object's SID already exists in destination forest
+      3221226522: The domain name of the trusted domain already exists in the forest
+      3221226523: The flat name of the trusted domain already exists in the forest
+      3221226524: The User Principal Name (UPN) is invalid
+      3221226528: There has been an assertion failure
+      3221226529: Application verifier has found an error in the current process
+      3221226531: A user mode unwind is in progress
+      3221226532: Incompatibility with this system. Contact your software vendor for a compatible version of the driver
+      3221226533: Illegal operation attempted on a registry key which has already been unloaded
+      3221226534: Compression is disabled for this volume
+      3221226535: The requested operation could not be completed due to a file system limitation
+      3221226536: The hash for image cannot be found in the system catalogs. The image is likely corrupt or the victim of tampering
+      3221226537: The implementation is not capable of performing the request
+      3221226538: The requested operation is out of order with respect to other operations
+      3221226539: An operation attempted to exceed an implementation-defined limit
+      3221226540: The requested operation requires elevation
+      3221226541: The required security context does not exist
+      3221226542: The PKU2U protocol encountered an error while attempting to utilize the associated certificates
+      3221226546: The operation was attempted beyond the valid data length of the file
+      3221226547: The attempted write operation encountered a write already in progress for some portion of the range
+      3221226548: The page fault mappings changed in the middle of processing a fault so the operation must be retried
+      3221226549: The attempt to purge this file from memory failed to purge some or all the data from memory
+      3221226560: The requested credential requires confirmation
+      3221226561: The remote server sent an invalid response for a file being opened with Client Side Encryption
+      3221226562: Client Side Encryption is not supported by the remote server even though it claims to support it
+      3221226563: File is encrypted and should be opened in Client Side Encryption mode
+      3221226564: A new encrypted file is being created and a $EFS needs to be provided
+      3221226565: The SMB client requested a CSE FSCTL on a non-CSE file
+      3221226566: Indicates a particular Security ID may not be assigned as the label of an object
+      3221226576: The process hosting the driver for this device has terminated
+      3221226577: The requested system device cannot be identified due to multiple indistinguishable devices potentially matching the identification criteria
+      3221226578: The requested system device cannot be found
+      3221226579: This boot application must be restarted
+      3221226580: Insufficient NVRAM resources exist to complete the API.  A reboot might be required
+      3221226592: No ranges for the specified operation were able to be processed
+      3221226595: The storage device does not support Offload Write
+      3221226596: Data cannot be moved because the source device cannot communicate with the destination device
+      3221226597: The token representing the data is invalid or expired
+      3221226752: The specified task name is invalid
+      3221226753: The specified task index is invalid
+      3221226754: The specified thread is already joining a task
+      3221226755: A callback has requested to bypass native code
+      3221227010: A fail fast exception occurred. Exception handlers will not be invoked and the process will be terminated immediately
+      3221227011: Windows cannot verify the digital signature for this file. The signing certificate for this file has been revoked
+      3221227264: The ALPC port is closed
+      3221227265: The ALPC message requested is no longer available
+      3221227266: The ALPC message supplied is invalid
+      3221227267: The ALPC message has been canceled
+      3221227268: Invalid recursive dispatch attempt
+      3221227269: No receive buffer has been supplied in a synchronous request
+      3221227270: The connection port is used in an invalid context
+      3221227271: The ALPC port does not accept new request messages
+      3221227272: The resource requested is already in use
+      3221227273: The hardware has reported an uncorrectable memory error
+      3221227274: Status 0x%08x was returned, waiting on handle 0x%x for wait 0x%p, in waiter 0x%p
+      3221227275: After a callback to 0x%p(0x%p), a completion call to Set event(0x%p) failed with status 0x%08x
+      3221227276: After a callback to 0x%p(0x%p), a completion call to ReleaseSemaphore(0x%p, %d) failed with status 0x%08x
+      3221227277: After a callback to 0x%p(0x%p), a completion call to ReleaseMutex(%p) failed with status 0x%08x
+      3221227278: After a callback to 0x%p(0x%p), a completion call to FreeLibrary(%p) failed with status 0x%08x
+      3221227279: The thread pool 0x%p was released while a thread was posting a callback to 0x%p(0x%p) to it
+      3221227280: A thread pool worker thread is impersonating a client, after a callback to 0x%p(0x%p). This is unexpected, indicating that the callback is missing a call to revert the impersonation
+      3221227281: A thread pool worker thread is impersonating a client, after executing an APC. This is unexpected, indicating that the APC is missing a call to revert the impersonation
+      3221227282: Either the target process, or the target thread's containing process, is a protected process
+      3221227283: A thread is getting dispatched with MCA EXCEPTION because of MCA
+      3221227284: The client certificate account mapping is not unique
+      3221227285: The symbolic link cannot be followed because its type is disabled
+      3221227286: Indicates that the specified string is not valid for IDN normalization
+      3221227287: No mapping for the Unicode character exists in the target multi-byte code page
+      3221227288: The provided callback is already registered
+      3221227289: The provided context did not match the target
+      3221227290: The specified port already has a completion list
+      3221227291: A threadpool worker thread entered a callback at thread base priority 0x%x and exited at priority 0x%x
+      3221227292: An invalid thread, handle %p, is specified for this operation. Possibly, a threadpool worker thread was specified
+      3221227293: A threadpool worker thread entered a callback, which left transaction state
+      3221227294: A threadpool worker thread entered a callback, which left the loader lock held
+      3221227295: A threadpool worker thread entered a callback, which left with preferred languages set
+      3221227296: A threadpool worker thread entered a callback, which left with background priorities set
+      3221227520: The attempted operation required self healing to be enabled
+      3221227521: The directory service cannot perform the requested operation because a domain rename operation is in progress
+      3221227522: An operation failed because the storage quota was exceeded
+      3221227524: An operation failed because the content was blocked
+      3221227525: The operation could not be completed due to bad clusters on disk
+      3221227526: The operation could not be completed because the volume is dirty. Please run the Chkdsk utility and try again. ]
+      3221227777: This file is checked out or locked for editing by another user
+      3221227778: The file must be checked out before saving changes
+      3221227779: The file type being saved or retrieved has been blocked
+      3221227780: The file size exceeds the limit allowed and cannot be saved
+      3221227781: Access Denied. Before opening files in this location, you must first browse to the e.g. site and select the option to log on automatically
+      3221227782: The operation did not complete successfully because the file contains a virus
+      3221227783: This file contains a virus and cannot be opened. Due to the nature of this virus, the file has been removed from this location
+      3221227784: The resources required for this device conflict with the MCFG table
+      3221227785: The operation did not complete successfully because it would cause an oplock to be broken. The caller has requested that existing oplocks not be broken
+      3221264536: WOW Assertion Error
+      3221266432: The cryptographic signature is invalid
+      3221266433: The cryptographic provider does not support HMAC
+      3221266448: The IPsec queue overflowed
+      3221266449: The neighbor discovery queue overflowed
+      3221266450: An Internet Control Message Protocol (ICMP) hop limit exceeded error was received
+      3221266451: The protocol is not installed on the local machine
+      3221266560: Windows was unable to save all the data for the file
+      3221266561: Windows was unable to save all the data for the file
+      3221266562: Windows was unable to save all the data for the file
+      3221266563: Windows was unable to parse the requested XML data
+      3221266564: An error was encountered while processing an XML digital signature
+      3221266565: This indicates that the caller made the connection request in the wrong routing compartment
+      3221266566: This indicates that there was an AuthIP failure when attempting to connect to the remote host
+      3221266567: OID mapped groups cannot have members
+      3221266568: The specified OID cannot be found
+      3221266688: Hash generation for the specified version and hash type is not enabled on server
+      3221266689: The hash requests is not present or not up to date with the current file contents
+      3221267105: A file system filter on the server has not opted in for Offload Read support
+      3221267106: A file system filter on the server has not opted in for Offload Write support
+      3221267107: Offload read operations cannot be performed on:]
+      3221267108: Offload write operations cannot be performed on:]
+      3221291009: The debugger did not perform a state change
+      3221291010: The debugger found that the application is not idle
+      3221356545: The string binding is invalid
+      3221356546: The binding handle is not the correct type
+      3221356547: The binding handle is invalid
+      3221356548: The RPC protocol sequence is not supported
+      3221356549: The RPC protocol sequence is invalid
+      3221356550: The string UUID is invalid
+      3221356551: The endpoint format is invalid
+      3221356552: The network address is invalid
+      3221356553: No endpoint was found
+      3221356554: The time-out value is invalid
+      3221356555: The object UUID was not found
+      3221356556: The object UUID has already been registered
+      3221356557: The type UUID has already been registered
+      3221356558: The RPC server is already listening
+      3221356559: No protocol sequences have been registered
+      3221356560: The RPC server is not listening
+      3221356561: The manager type is unknown
+      3221356562: The interface is unknown
+      3221356563: There are no bindings
+      3221356564: There are no protocol sequences
+      3221356565: The endpoint cannot be created
+      3221356566: Insufficient resources are available to complete this operation
+      3221356567: The RPC server is unavailable
+      3221356568: The RPC server is too busy to complete this operation
+      3221356569: The network options are invalid
+      3221356570: No RPCs are active on this thread
+      3221356571: The RPC failed
+      3221356572: The RPC failed and did not execute
+      3221356573: An RPC protocol error occurred
+      3221356575: The RPC server does not support the transfer syntax
+      3221356577: The type UUID is not supported
+      3221356578: The tag is invalid
+      3221356579: The array bounds are invalid
+      3221356580: The binding does not contain an entry name
+      3221356581: The name syntax is invalid
+      3221356582: The name syntax is not supported
+      3221356584: No network address is available to construct a UUID
+      3221356585: The endpoint is a duplicate
+      3221356586: The authentication type is unknown
+      3221356587: The maximum number of calls is too small
+      3221356588: The string is too long
+      3221356589: The RPC protocol sequence was not found
+      3221356590: The procedure number is out of range
+      3221356591: The binding does not contain any authentication information
+      3221356592: The authentication service is unknown
+      3221356593: The authentication level is unknown
+      3221356594: The security context is invalid
+      3221356595: The authorization service is unknown
+      3221356596: The entry is invalid
+      3221356597: The operation cannot be performed
+      3221356598: No more endpoints are available from the endpoint mapper
+      3221356599: No interfaces have been exported
+      3221356600: The entry name is incomplete
+      3221356601: The version option is invalid
+      3221356602: There are no more members
+      3221356603: There is nothing to unexport
+      3221356604: The interface was not found
+      3221356605: The entry already exists
+      3221356606: The entry was not found
+      3221356607: The name service is unavailable
+      3221356608: The network address family is invalid
+      3221356609: The requested operation is not supported
+      3221356610: No security context is available to allow impersonation
+      3221356611: An internal error occurred in the RPC
+      3221356612: The RPC server attempted to divide an integer by zero
+      3221356613: An addressing error occurred in the RPC server
+      3221356614: A floating point operation at the RPC server caused a divide by zero
+      3221356615: A floating point underflow occurred at the RPC server
+      3221356616: A floating point overflow occurred at the RPC server
+      3221356617: An RPC is already in progress for this thread
+      3221356618: There are no more bindings
+      3221356619: The group member was not found
+      3221356620: The endpoint mapper database entry could not be created
+      3221356621: The object UUID is the nil UUID
+      3221356623: No interfaces have been registered
+      3221356624: The RPC was canceled
+      3221356625: The binding handle does not contain all the required information
+      3221356626: A communications failure occurred during an RPC
+      3221356627: The requested authentication level is not supported
+      3221356628: No principal name was registered
+      3221356629: The error specified is not a valid Windows RPC error code
+      3221356631: A security package-specific error occurred
+      3221356632: The thread was not canceled
+      3221356642: Invalid asynchronous RPC handle
+      3221356643: Invalid asynchronous RPC call handle for this operation
+      3221356644: Access to the HTTP proxy is denied
+      3221422081: The list of RPC servers available for auto-handle binding has been exhausted
+      3221422082: The file designated by DCERPCCHARTRANS cannot be opened
+      3221422083: The file containing the character translation table has fewer than 512 bytes
+      3221422084: A null context handle is passed as an [in] parameter
+      3221422085: The context handle does not match any known context handles
+      3221422086: The context handle changed during a call
+      3221422087: The binding handles passed to an RPC do not match
+      3221422088: The stub is unable to get the call handle
+      3221422089: A null reference pointer was passed to the stub
+      3221422090: The enumeration value is out of range
+      3221422091: The byte count is too small
+      3221422092: The stub received bad data
+      3221422169: Invalid operation on the encoding/decoding handle
+      3221422170: Incompatible version of the serializing package
+      3221422171: Incompatible version of the RPC stub
+      3221422172: The RPC pipe object is invalid or corrupt
+      3221422173: An invalid operation was attempted on an RPC pipe object
+      3221422174: Unsupported RPC pipe version
+      3221422175: The RPC pipe object has already been closed
+      3221422176: The RPC call completed before all pipes were processed
+      3221422177: No more data is available from the RPC pipe
+      3221487669: A device is missing in the system BIOS MPS table. This device will not be used. Contact your system vendor for a system BIOS update
+      3221487670: A translator failed to translate resources
+      3221487671: An IRQ translator failed to translate resources
+      3221487672: Driver %2 returned an invalid ID for a child device (%3)
+      3221487673: Reissue the given operation as a cached I/O operation]
+      3221880833: Session name %1 is invalid
+      3221880834: The protocol driver %1 is invalid
+      3221880835: The protocol driver %1 was not found in the system path
+      3221880838: A close operation is pending on the terminal connection
+      3221880839: No free output buffers are available
+      3221880840: The MODEM.INF file was not found
+      3221880841: The modem (%1) was not found in the MODEM.INF file
+      3221880842: The modem did not accept the command sent to it. Verify that the configured modem name matches the attached modem
+      3221880843: The modem did not respond to the command sent to it. Verify that the modem cable is properly attached and the modem is turned on
+      3221880844: Carrier detection has failed or the carrier has been dropped due to disconnection
+      3221880845: A dial tone was not detected within the required time. Verify that the phone cable is properly attached and functional
+      3221880846: A busy signal was detected at a remote site on callback
+      3221880847: A voice was detected at a remote site on callback
+      3221880848: Transport driver error
+      3221880850: The client you are using is not licensed to use this system. Your logon request is denied
+      3221880851: The system has reached its licensed logon limit. Try again later
+      3221880852: The system license has expired. Your logon request is denied
+      3221880853: The specified session cannot be found
+      3221880854: The specified session name is already in use
+      3221880855: The requested operation cannot be completed because the terminal connection is currently processing a connect, disconnect, reset, or delete operation
+      3221880856: An attempt has been made to connect to a session whose video mode is not supported by the current client
+      3221880866: The application attempted to enable DOS graphics mode. DOS graphics mode is not supported
+      3221880868: The requested operation can be performed only on the system console. This is most often the result of a driver or system DLL requiring direct console access
+      3221880870: The client failed to respond to the server connect message
+      3221880871: Disconnecting the console session is not supported
+      3221880872: Reconnecting a disconnected session to the console is not supported
+      3221880874: The request to control another session remotely was denied
+      3221880875: A process has requested access to a session, but has not been granted those access rights
+      3221880878: The terminal connection driver %1 is invalid
+      3221880879: The terminal connection driver %1 was not found in the system path
+      3221880880: The requested session cannot be controlled remotely. You cannot control your own session, a session that is trying to control your session, a session that has no user logged on, or other sessions from the console
+      3221880881: The requested session is not configured to allow remote control
+      3221880882: The RDP protocol component %2 detected an error in the protocol stream and has disconnected the client
+      3221880883: Your request to connect to this terminal server has been rejected. Your terminal server client license number has not been entered for this copy of the terminal client. Contact your system administrator for help in entering a valid, unique license number for this terminal server client. Click OK to continue
+      3221880884: Your request to connect to this terminal server has been rejected. Your terminal server client license number is currently being used by another user. Contact your system administrator to obtain a new copy of the terminal server client with a valid, unique license number. Click OK to continue
+      3221880885: The remote control of the console was terminated because the display mode was changed. Changing the display mode in a remote control session is not supported
+      3221880886: Remote control could not be terminated because the specified session is not currently being remotely controlled
+      3221880887: Your interactive logon privilege has been disabled. Contact your system administrator
+      3221880888: The terminal server security layer detected an error in the protocol stream and has disconnected the client
+      3221880889: The target session is incompatible with the current session
+      3221946369: The resource loader failed to find an MUI file
+      3221946370: The resource loader failed to load an MUI file because the file failed to pass validation
+      3221946371: The RC manifest is corrupted with garbage data, is an unsupported version, or is missing a required item
+      3221946372: The RC manifest has an invalid culture name
+      3221946373: The RC manifest has and invalid ultimate fallback name
+      3221946374: The resource loader cache does not have a loaded MUI entry
+      3221946375: The user stopped resource enumeration
+      3222470657: The cluster node is not valid
+      3222470658: The cluster node already exists
+      3222470659: A node is in the process of joining the cluster
+      3222470660: The cluster node was not found
+      3222470661: The cluster local node information was not found
+      3222470662: The cluster network already exists
+      3222470663: The cluster network was not found
+      3222470664: The cluster network interface already exists
+      3222470665: The cluster network interface was not found
+      3222470666: The cluster request is not valid for this object
+      3222470667: The cluster network provider is not valid
+      3222470668: The cluster node is down
+      3222470669: The cluster node is not reachable
+      3222470670: The cluster node is not a member of the cluster
+      3222470671: A cluster join operation is not in progress
+      3222470672: The cluster network is not valid
+      3222470673: No network adapters are available
+      3222470674: The cluster node is up
+      3222470675: The cluster node is paused
+      3222470676: The cluster node is not paused
+      3222470677: No cluster security context is available
+      3222470678: The cluster network is not configured for internal cluster communication
+      3222470679: The cluster node has been poisoned
+      3222536193: An attempt was made to run an invalid AML opcode
+      3222536194: The AML interpreter stack has overflowed
+      3222536195: An inconsistent state has occurred
+      3222536196: An attempt was made to access an array outside its bounds
+      3222536197: A required argument was not specified
+      3222536198: A fatal error has occurred
+      3222536199: An invalid SuperName was specified
+      3222536200: An argument with an incorrect type was specified
+      3222536201: An object with an incorrect type was specified
+      3222536202: A target with an incorrect type was specified
+      3222536203: An incorrect number of arguments was specified
+      3222536204: An address failed to translate
+      3222536205: An incorrect event type was specified
+      3222536206: A handler for the target already exists
+      3222536207: Invalid data for the target was specified
+      3222536208: An invalid region for the target was specified
+      3222536209: An attempt was made to access a field outside the defined range
+      3222536210: The global system lock could not be acquired
+      3222536211: An attempt was made to reinitialize the ACPI subsystem
+      3222536212: The ACPI subsystem has not been initialized
+      3222536213: An incorrect mutex was specified
+      3222536214: The mutex is not currently owned
+      3222536215: An attempt was made to access the mutex by a process that was not the owner
+      3222536216: An error occurred during an access to region space
+      3222536217: An attempt was made to use an incorrect table
+      3222536224: The registration of an ACPI event failed
+      3222536225: An ACPI power object failed to transition state
+      3222601729: The requested section is not present in the activation context
+      3222601730: 0xC0150003<br />STATUS_SXS_INVALID_ACTCTXDATA_FORMAT]
+      3222601732: The referenced assembly is not installed on the system
+      3222601733: The manifest file does not begin with the required tag and format information
+      3222601734: The manifest file contains one or more syntax errors
+      3222601735: The application attempted to activate a disabled activation context
+      3222601736: The requested lookup key was not found in any active activation context
+      3222601737: A component version required by the application conflicts with another component version that is already active
+      3222601738: The type requested activation context section does not match the query API used
+      3222601739: Lack of system resources has required isolated activation to be disabled for the current thread of execution
+      3222601740: The referenced assembly could not be found
+      3222601742: An attempt to set the process default activation context failed because the process default activation context was already set
+      3222601743: The activation context being deactivated is not the most recently activated one
+      3222601744: The activation context being deactivated is not active for the current thread of execution
+      3222601745: The activation context being deactivated has already been deactivated
+      3222601746: The activation context of the system default assembly could not be generated
+      3222601747: A component used by the isolation facility has requested that the process be terminated
+      3222601748: The activation context activation stack for the running thread of execution is corrupt
+      3222601749: The application isolation metadata for this process or thread has become corrupt
+      3222601750: The value of an attribute in an identity is not within the legal range
+      3222601751: The name of an attribute in an identity is not within the legal range
+      3222601752: An identity contains two definitions for the same attribute
+      3222601753: The identity string is malformed. This may be due to a trailing comma, more than two unnamed attributes, a missing attribute name, or a missing attribute value
+      3222601754: The component store has become corrupted
+      3222601755: A component's file does not match the verification information present in the component manifest
+      3222601756: The identities of the manifests are identical, but their contents are different
+      3222601757: The component identities are different
+      3222601758: The assembly is not a deployment
+      3222601759: The file is not a part of the assembly
+      3222601760: An advanced installer failed during setup or servicing
+      3222601761: The character encoding in the XML declaration did not match the encoding used in the document
+      3222601762: The size of the manifest exceeds the maximum allowed
+      3222601763: The setting is not registered
+      3222601764: One or more required transaction members are not present
+      3222601765: The SMI primitive installer failed during setup or servicing
+      3222601766: A generic command executable returned a result that indicates failure
+      3222601767: A component is missing file verification information in its manifest
+      3222863873: The function attempted to use a name that is reserved for use by another transaction
+      3222863874: The transaction handle associated with this operation is invalid
+      3222863875: The requested operation was made in the context of a transaction that is no longer active
+      3222863876: The transaction manager was unable to be successfully initialized. Transacted operations are not supported
+      3222863877: Transaction support within the specified file system resource manager was not started or was shut down due to an error
+      3222863878: The metadata of the resource manager has been corrupted. The resource manager will not function
+      3222863879: The resource manager attempted to prepare a transaction that it has not successfully joined
+      3222863880: The specified directory does not contain a file system resource manager
+      3222863882: The remote server or share does not support transacted file operations
+      3222863883: The requested log size for the file system resource manager is invalid
+      3222863884: The remote server sent mismatching version number or Fid for a file opened with transactions
+      3222863887: The resource manager tried to register a protocol that already exists
+      3222863888: The attempt to propagate the transaction failed
+      3222863889: The requested propagation protocol was not registered as a CRM
+      3222863890: The transaction object already has a superior enlistment, and the caller attempted an operation that would have created a new superior. Only a single superior enlistment is allowed
+      3222863891: The requested operation is not valid on the transaction object in its current state
+      3222863892: The caller has called a response API, but the response is not expected because the transaction manager did not issue the corresponding request to the caller
+      3222863893: It is too late to perform the requested operation, because the transaction has already been aborted
+      3222863894: It is too late to perform the requested operation, because the transaction has already been committed
+      3222863895: The buffer passed in to NtPushTransaction or NtPullTransaction is not in a valid format
+      3222863896: The current transaction context associated with the thread is not a valid handle to a transaction object
+      3222863897: An attempt to create space in the transactional resource manager's log failed. The failure status has been recorded in the event log
+      3222863905: The object (file, stream, or link) that corresponds to the handle has been deleted by a transaction savepoint rollback
+      3222863906: The specified file miniversion was not found for this transacted file open
+      3222863907: The specified file miniversion was found but has been invalidated. The most likely cause is a transaction savepoint rollback
+      3222863908: A miniversion may be opened only in the context of the transaction that created it
+      3222863909: It is not possible to open a miniversion with modify access
+      3222863910: It is not possible to create any more miniversions for this stream
+      3222863912: The handle has been invalidated by a transaction. The most likely cause is the presence of memory mapping on a file or an open handle when the transaction ended or rolled back to savepoint
+      3222863920: The log data is corrupt
+      3222863922: The transaction outcome is unavailable because the resource manager responsible for it is disconnected
+      3222863923: The request was rejected because the enlistment in question is not a superior enlistment
+      3222863926: The file cannot be opened in a transaction because its identity depends on the outcome of an unresolved transaction
+      3222863927: The operation cannot be performed because another transaction is depending on this property not changing
+      3222863928: The operation would involve a single file with two transactional resource managers and is, therefore, not allowed
+      3222863929: The $Txf directory must be empty for this operation to succeed
+      3222863930: The operation would leave a transactional resource manager in an inconsistent state and is therefore not allowed
+      3222863931: The operation could not be completed because the transaction manager does not have a log
+      3222863932: A rollback could not be scheduled because a previously scheduled rollback has already executed or been queued for execution
+      3222863933: The transactional metadata attribute on the file or directory is corrupt and unreadable
+      3222863934: The encryption operation could not be completed because a transaction is active
+      3222863935: This object is not allowed to be opened in a transaction
+      3222863936: Memory mapping (creating a mapped section) a remote file under a transaction is not supported
+      3222863939: Promotion was required to allow the resource manager to enlist, but the transaction was set to disallow it
+      3222863940: This file is open for modification in an unresolved transaction and may be opened for execute only by a transacted reader
+      3222863941: The request to thaw frozen transactions was ignored because transactions were not previously frozen
+      3222863942: Transactions cannot be frozen because a freeze is already in progress
+      3222863943: The target volume is not a snapshot volume. This operation is valid only on a volume mounted as a snapshot
+      3222863944: The savepoint operation failed because files are open on the transaction, which is not permitted
+      3222863945: The sparse operation could not be completed because a transaction is active on the file
+      3222863946: The call to create a transaction manager object failed because the Tm Identity that is stored in the log file does not match the Tm Identity that was passed in as an argument
+      3222863947: I/O was attempted on a section object that has been floated as a result of a transaction ending. There is no valid data
+      3222863948: The transactional resource manager cannot currently accept transacted work due to a transient condition, such as low resources
+      3222863949: The transactional resource manager had too many transactions outstanding that could not be aborted. The transactional resource manager has been shut down
+      3222863950: The specified transaction was unable to be opened because it was not found
+      3222863951: The specified resource manager was unable to be opened because it was not found
+      3222863952: The specified enlistment was unable to be opened because it was not found
+      3222863953: The specified transaction manager was unable to be opened because it was not found
+      3222863954: The specified resource manager was unable to create an enlistment because its associated transaction manager is not online
+      3222863955: The specified transaction manager was unable to create the objects contained in its log file in the Ob namespace. Therefore, the transaction manager was unable to recover
+      3222863956: The call to create a superior enlistment on this transaction object could not be completed because the transaction object specified for the enlistment is a subordinate branch of the transaction. Only the root of the transaction can be enlisted as a superior
+      3222863957: Because the associated transaction manager or resource manager has been closed, the handle is no longer valid
+      3222863958: The compression operation could not be completed because a transaction is active on the file
+      3222863959: The specified operation could not be performed on this superior enlistment because the enlistment was not created with the corresponding completion response in the NotificationMask
+      3222863960: The specified operation could not be performed because the record to be logged was too long. This can occur because either there are too many enlistments on this transaction or the combined RecoveryInformation being logged on behalf of those enlistments is too long
+      3222863961: The link-tracking operation could not be completed because a transaction is active
+      3222863962: This operation cannot be performed in a transaction
+      3222863963: The kernel transaction manager had to abort or forget the transaction because it blocked forward progress
+      3222863968: The handle is no longer properly associated with its transaction.  It may have been opened in a transactional resource manager that was subsequently forced to restart.  Please close the handle and open a new one
+      3222863969: The specified operation could not be performed because the resource manager is not enlisted in the transaction
+      3222929409: The log service found an invalid log sector
+      3222929410: The log service encountered a log sector with invalid block parity
+      3222929411: The log service encountered a remapped log sector
+      3222929412: The log service encountered a partial or incomplete log block
+      3222929413: The log service encountered an attempt to access data outside the active log range
+      3222929414: The log service user-log marshaling buffers are exhausted
+      3222929415: The log service encountered an attempt to read from a marshaling area with an invalid read context
+      3222929416: The log service encountered an invalid log restart area
+      3222929417: The log service encountered an invalid log block version
+      3222929418: The log service encountered an invalid log block
+      3222929419: The log service encountered an attempt to read the log with an invalid read mode
+      3222929421: The log service encountered a corrupted metadata file
+      3222929422: The log service encountered a metadata file that could not be created by the log file system
+      3222929423: The log service encountered a metadata file with inconsistent data
+      3222929424: The log service encountered an attempt to erroneously allocate or dispose reservation space
+      3222929425: The log service cannot delete the log file or the file system container
+      3222929426: The log service has reached the maximum allowable containers allocated to a log file
+      3222929427: The log service has attempted to read or write backward past the start of the log
+      3222929428: The log policy could not be installed because a policy of the same type is already present
+      3222929429: The log policy in question was not installed at the time of the request
+      3222929430: The installed set of policies on the log is invalid
+      3222929431: A policy on the log in question prevented the operation from completing
+      3222929432: The log space cannot be reclaimed because the log is pinned by the archive tail
+      3222929433: The log record is not a record in the log file
+      3222929434: The number of reserved log records or the adjustment of the number of reserved log records is invalid
+      3222929435: The reserved log space or the adjustment of the log space is invalid
+      3222929436: A new or existing archive tail or the base of the active log is invalid
+      3222929437: The log space is exhausted
+      3222929438: The log is multiplexed; no direct writes to the physical log are allowed
+      3222929439: The operation failed because the log is dedicated
+      3222929440: The operation requires an archive context
+      3222929441: Log archival is in progress
+      3222929442: The operation requires a nonephemeral log, but the log is ephemeral
+      3222929443: The log must have at least two containers before it can be read from or written to
+      3222929444: A log client has already registered on the stream
+      3222929445: A log client has not been registered on the stream
+      3222929446: A request has already been made to handle the log full condition
+      3222929447: The log service encountered an error when attempting to read from a log container
+      3222929448: The log service encountered an error when attempting to write to a log container
+      3222929449: The log service encountered an error when attempting to open a log container
+      3222929450: The log service encountered an invalid container state when attempting a requested action
+      3222929451: The log service is not in the correct state to perform a requested action
+      3222929452: The log space cannot be reclaimed because the log is pinned
+      3222929453: The log metadata flush failed
+      3222929454: Security on the log and its containers is inconsistent
+      3222929455: Records were appended to the log or reservation changes were made, but the log could not be flushed
+      3222929456: The log is pinned due to reservation consuming most of the log space. Free some reserved records to make space available
+      3222995178: The display driver has stopped working normally. Save your work and reboot the system to restore full display functionality. The next time you reboot the computer, a dialog box will allow you to upload data about this failure to Microsoft
+      3223060481: A handler was not defined by the filter for this operation
+      3223060482: A context is already defined for this object
+      3223060483: Asynchronous requests are not valid for this operation
+      3223060484: This is an internal error code used by the filter manager to determine if a fast I/O operation should be forced down the input/output request packet (IRP) path. Minifilters should never return this value
+      3223060485: An invalid name request was made. The name requested cannot be retrieved at this time
+      3223060486: Posting this operation to a worker thread for further processing is not safe at this time because it could lead to a system deadlock
+      3223060487: The Filter Manager was not initialized when a filter tried to register. Make sure that the Filter Manager is loaded as a driver
+      3223060488: The filter is not ready for attachment to volumes because it has not finished initializing (FltStartFiltering has not been called)
+      3223060489: The filter must clean up any operation-specific context at this time because it is being removed from the system before the operation is completed by the lower drivers
+      3223060490: The Filter Manager had an internal error from which it cannot recover; therefore, the operation has failed. This is usually the result of a filter returning an invalid value from a pre-operation callback
+      3223060491: The object specified for this action is in the process of being deleted; therefore, the action requested cannot be completed at this time
+      3223060492: A nonpaged pool must be used for this type of context
+      3223060493: A duplicate handler definition has been provided for an operation
+      3223060494: The callback data queue has been disabled
+      3223060495: Do not attach the filter to the volume at this time
+      3223060496: Do not detach the filter from the volume at this time
+      3223060497: An instance already exists at this altitude on the volume specified
+      3223060498: An instance already exists with this name on the volume specified
+      3223060499: The system could not find the filter specified
+      3223060500: The system could not find the volume specified
+      3223060501: The system could not find the instance specified
+      3223060502: No registered context allocation definition was found for the given request
+      3223060503: An invalid parameter was specified during context registration
+      3223060504: The name requested was not found in the Filter Manager name cache and could not be retrieved from the file system
+      3223060505: The requested device object does not exist for the given volume
+      3223060506: The specified volume is already mounted
+      3223060507: The specified transaction context is already enlisted in a transaction
+      3223060508: The specified context is already attached to another object
+      3223060512: No waiter is present for the filter's reply to this message
+      3223126017: A monitor descriptor could not be obtained
+      3223126018: This release does not support the format of the obtained monitor descriptor
+      3223126019: The checksum of the obtained monitor descriptor is invalid
+      3223126020: The monitor descriptor contains an invalid standard timing block
+      3223126021: WMI data-block registration failed for one of the MSMonitorClass WMI subclasses
+      3223126022: The provided monitor descriptor block is either corrupted or does not contain the monitor's detailed serial number
+      3223126023: The provided monitor descriptor block is either corrupted or does not contain the monitor's user-friendly name
+      3223126024: There is no monitor descriptor data at the specified (offset or size) region
+      3223126025: The monitor descriptor contains an invalid detailed timing block
+      3223126026: Monitor descriptor contains invalid manufacture date
+      3223191552: Exclusive mode ownership is needed to create an unmanaged primary allocation
+      3223191553: The driver needs more DMA buffer space to complete the requested operation
+      3223191554: The specified display adapter handle is invalid
+      3223191555: The specified display adapter and all of its state have been reset
+      3223191556: The driver stack does not match the expected driver model
+      3223191557: Present happened but ended up into the changed desktop mode
+      3223191558: Nothing to present due to desktop occlusion
+      3223191559: Not able to present due to denial of desktop access
+      3223191560: Not able to present with color conversion
+      3223191563: Present redirection is disabled (desktop windowing management subsystem is off)
+      3223191564: Previous exclusive VidPn source owner has released its ownership]
+      3223191808: Not enough video memory is available to complete the operation
+      3223191809: Could not probe and lock the underlying memory of an allocation
+      3223191810: The allocation is currently busy
+      3223191811: An object being referenced has already reached the maximum reference count and cannot be referenced further
+      3223191812: A problem could not be solved due to an existing condition. Try again later
+      3223191813: A problem could not be solved due to an existing condition. Try again now
+      3223191814: The allocation is invalid
+      3223191815: No more unswizzling apertures are currently available
+      3223191816: The current allocation cannot be unswizzled by an aperture
+      3223191817: The request failed because a pinned allocation cannot be evicted
+      3223191824: The allocation cannot be used from its current segment location for the specified operation
+      3223191825: A locked allocation cannot be used in the current command buffer
+      3223191826: The allocation being referenced has been closed permanently
+      3223191827: An invalid allocation instance is being referenced
+      3223191828: An invalid allocation handle is being referenced
+      3223191829: The allocation being referenced does not belong to the current device
+      3223191830: The specified allocation lost its content
+      3223192064: A GPU exception was detected on the given device. The device cannot be scheduled
+      3223192320: The specified VidPN topology is invalid
+      3223192321: The specified VidPN topology is valid but is not supported by this model of the display adapter
+      3223192322: The specified VidPN topology is valid but is not currently supported by the display adapter due to allocation of its resources
+      3223192323: The specified VidPN handle is invalid
+      3223192324: The specified video present source is invalid
+      3223192325: The specified video present target is invalid
+      3223192326: The specified VidPN modality is not supported (for example, at least two of the pinned modes are not co-functional)
+      3223192328: The specified VidPN source mode set is invalid
+      3223192329: The specified VidPN target mode set is invalid
+      3223192330: The specified video signal frequency is invalid
+      3223192331: The specified video signal active region is invalid
+      3223192332: The specified video signal total region is invalid
+      3223192336: The specified video present source mode is invalid
+      3223192337: The specified video present target mode is invalid
+      3223192338: The pinned mode must remain in the set on the VidPN's co-functional modality enumeration
+      3223192339: The specified video present path is already in the VidPN's topology
+      3223192340: The specified mode is already in the mode set
+      3223192341: The specified video present source set is invalid
+      3223192342: The specified video present target set is invalid
+      3223192343: The specified video present source is already in the video present source set
+      3223192344: The specified video present target is already in the video present target set
+      3223192345: The specified VidPN present path is invalid
+      3223192346: The miniport has no recommendation for augmenting the specified VidPN's topology
+      3223192347: The specified monitor frequency range set is invalid
+      3223192348: The specified monitor frequency range is invalid
+      3223192349: The specified frequency range is not in the specified monitor frequency range set
+      3223192351: The specified frequency range is already in the specified monitor frequency range set
+      3223192352: The specified mode set is stale. Reacquire the new mode set
+      3223192353: The specified monitor source mode set is invalid
+      3223192354: The specified monitor source mode is invalid
+      3223192355: The miniport does not have a recommendation regarding the request to provide a functional VidPN given the current display adapter configuration
+      3223192356: The ID of the specified mode is being used by another mode in the set
+      3223192357: The system failed to determine a mode that is supported by both the display adapter and the monitor connected to it
+      3223192358: The number of video present targets must be greater than or equal to the number of video present sources
+      3223192359: The specified present path is not in the VidPN's topology
+      3223192360: The display adapter must have at least one video present source
+      3223192361: The display adapter must have at least one video present target
+      3223192362: The specified monitor descriptor set is invalid
+      3223192363: The specified monitor descriptor is invalid
+      3223192364: The specified descriptor is not in the specified monitor descriptor set
+      3223192365: The specified descriptor is already in the specified monitor descriptor set
+      3223192366: The ID of the specified monitor descriptor is being used by another descriptor in the set
+      3223192367: The specified video present target subset type is invalid
+      3223192368: Two or more of the specified resources are not related to each other, as defined by the interface semantics
+      3223192369: The ID of the specified video present source is being used by another source in the set
+      3223192370: The ID of the specified video present target is being used by another target in the set
+      3223192371: The specified VidPN source cannot be used because there is no available VidPN target to connect it to
+      3223192372: The newly arrived monitor could not be associated with a display adapter
+      3223192373: The particular display adapter does not have an associated VidPN manager
+      3223192374: The VidPN manager of the particular display adapter does not have an active VidPN
+      3223192375: The specified VidPN topology is stale; obtain the new topology
+      3223192376: No monitor is connected on the specified video present target
+      3223192377: The specified source is not part of the specified VidPN's topology
+      3223192378: The specified primary surface size is invalid
+      3223192379: The specified visible region size is invalid
+      3223192380: The specified stride is invalid
+      3223192381: The specified pixel format is invalid
+      3223192382: The specified color basis is invalid
+      3223192383: The specified pixel value access mode is invalid
+      3223192384: The specified target is not part of the specified VidPN's topology
+      3223192385: Failed to acquire the display mode management interface
+      3223192386: The specified VidPN source is already owned by a DMM client and cannot be used until that client releases it
+      3223192387: The specified VidPN is active and cannot be accessed
+      3223192388: The specified VidPN's present path importance ordinal is invalid
+      3223192389: The specified VidPN's present path content geometry transformation is invalid
+      3223192390: The specified content geometry transformation is not supported on the respective VidPN present path
+      3223192391: The specified gamma ramp is invalid
+      3223192392: The specified gamma ramp is not supported on the respective VidPN present path
+      3223192393: Multisampling is not supported on the respective VidPN present path
+      3223192394: The specified mode is not in the specified mode set
+      3223192397: The specified VidPN topology recommendation reason is invalid
+      3223192398: The specified VidPN present path content type is invalid
+      3223192399: The specified VidPN present path copy protection type is invalid
+      3223192400: Only one unassigned mode set can exist at any one time for a particular VidPN source or target
+      3223192402: The specified scan line ordering type is invalid
+      3223192403: The topology changes are not allowed for the specified VidPN
+      3223192404: All available importance ordinals are being used in the specified topology
+      3223192405: The specified primary surface has a different private-format attribute than the current primary surface
+      3223192406: The specified mode-pruning algorithm is invalid
+      3223192407: The specified monitor-capability origin is invalid
+      3223192408: The specified monitor-frequency range constraint is invalid
+      3223192409: The maximum supported number of present paths has been reached
+      3223192410: The miniport requested that augmentation be canceled for the specified source of the specified VidPN's topology
+      3223192411: The specified client type was not recognized
+      3223192412: The client VidPN is not set on this adapter (for example, no user mode-initiated mode changes have taken place on this adapter)
+      3223192576: The specified display adapter child device already has an external device connected to it
+      3223192577: The display adapter child device does not support reporting a descriptor
+      3223192624: The display adapter is not linked to any other adapters
+      3223192625: The lead adapter in a linked configuration was not enumerated yet
+      3223192626: Some chain adapters in a linked configuration have not yet been enumerated
+      3223192627: The chain of linked adapters is not ready to start because of an unknown failure
+      3223192628: An attempt was made to start a lead link display adapter when the chain links had not yet started
+      3223192629: An attempt was made to turn on a lead link display adapter when the chain links were turned off
+      3223192630: The adapter link was found in an inconsistent state. Not all adapters are in an expected PNP/power state
+      3223192632: The driver trying to start is not the same as the driver for the posted display adapter
+      3223192635: An operation is being attempted that requires the display adapter to be in a quiescent state
+      3223192832: The driver does not support OPM
+      3223192833: The driver does not support COPP
+      3223192834: The driver does not support UAB
+      3223192835: The specified encrypted parameters are invalid
+      3223192836: An array passed to a function cannot hold all of the data that the function wants to put in it
+      3223192837: The GDI display device passed to this function does not have any active protected outputs
+      3223192838: The PVP cannot find an actual GDI display device that corresponds to the passed-in GDI display device name
+      3223192839: This function failed because the GDI display device passed to it was not attached to the Windows desktop
+      3223192840: The PVP does not support mirroring display devices because they do not have any protected outputs
+      3223192842: The function failed because an invalid pointer parameter was passed to it. A pointer parameter is invalid if it is null, is not correctly aligned, or it points to an invalid address or a kernel mode address
+      3223192843: An internal error caused an operation to fail
+      3223192844: The function failed because the caller passed in an invalid OPM user-mode handle
+      3223192845: This function failed because the GDI device passed to it did not have any monitors associated with it
+      3223192846: A certificate could not be returned because the certificate buffer passed to the function was too small
+      3223192847: DxgkDdiOpmCreateProtectedOutput() could not create a protected output because the video present yarget is in spanning mode
+      3223192848: DxgkDdiOpmCreateProtectedOutput() could not create a protected output because the video present target is in theater mode
+      3223192849: The function call failed because the display adapter's hardware functionality scan (HFS) failed to validate the graphics hardware
+      3223192850: The HDCP SRM passed to this function did not comply with section 5 of the HDCP 1.1 specification
+      3223192851: The protected output cannot enable the HDCP system because it does not support it
+      3223192852: The protected output cannot enable analog copy protection because it does not support it
+      3223192853: The protected output cannot enable the CGMS-A protection technology because it does not support it
+      3223192854: DxgkDdiOPMGetInformation() cannot return the version of the SRM being used because the application never successfully passed an SRM to the protected output
+      3223192855: DxgkDdiOPMConfigureProtectedOutput() cannot enable the specified output protection technology because the output's screen resolution is too high
+      3223192856: DxgkDdiOPMConfigureProtectedOutput() cannot enable HDCP because other physical outputs are using the display adapter's HDCP hardware
+      3223192858: The operating system asynchronously destroyed this OPM-protected output because the operating system state changed. This error typically occurs because the monitor PDO associated with this protected output was removed or stopped, the protected output's session became a nonconsole session, or the protected output's desktop became inactive
+      3223192859: OPM functions cannot be called when a session is changing its type
+      3223192860: The DxgkDdiOPMGetCOPPCompatibleInformation, DxgkDdiOPMGetInformation, or DxgkDdiOPMConfigureProtectedOutput function failed. This error is returned only if a protected output has OPM semantics. ]
+      3223192861: The DxgkDdiOPMGetInformation and DxgkDdiOPMGetCOPPCompatibleInformation functions return this error code if the passed-in sequence number is not the expected sequence number or the passed-in OMAC value is invalid
+      3223192862: The function failed because an unexpected error occurred inside a display driver
+      3223192863: The DxgkDdiOPMGetCOPPCompatibleInformation, DxgkDdiOPMGetInformation, or DxgkDdiOPMConfigureProtectedOutput function failed. This error is returned only if a protected output has COPP semantics. ]
+      3223192864: The DxgkDdiOPMGetCOPPCompatibleInformation and DxgkDdiOPMConfigureProtectedOutput functions return this error if the display driver does not support the DXGKMDT_OPM_GET_ACP_AND_CGMSA_SIGNALING and DXGKMDT_OPM_SET_ACP_AND_CGMSA_SIGNALING GUIDs
+      3223192865: The DxgkDdiOPMConfigureProtectedOutput function returns this error code if the passed-in sequence number is not the expected sequence number or the passed-in OMAC value is invalid
+      3223192960: The monitor connected to the specified video output does not have an I2C bus
+      3223192961: No device on the I2C bus has the specified address
+      3223192962: An error occurred while transmitting data to the device on the I2C bus
+      3223192963: An error occurred while receiving data from the device on the I2C bus
+      3223192964: The monitor does not support the specified VCP code
+      3223192965: The data received from the monitor is invalid
+      3223192966: A function call failed because a monitor returned an invalid timing status byte when the operating system used the DDC/CI get timing report and timing message command to get a timing report from a monitor
+      3223192967: A monitor returned a DDC/CI capabilities string that did not comply with the ACCESS.bus 3.0, DDC/CI 1.1, or MCCS 2 Revision 1 specification
+      3223192968: An internal error caused an operation to fail
+      3223192969: An operation failed because a DDC/CI message had an invalid value in its command field
+      3223192970: This error occurred because a DDC/CI message had an invalid value in its length field
+      3223192971: This error occurred because the value in a DDC/CI message's checksum field did not match the message's computed checksum value. This error implies that the data was corrupted while it was being transmitted from a monitor to a computer
+      3223192972: This function failed because an invalid monitor handle was passed to it
+      3223192973: The operating system asynchronously destroyed the monitor that corresponds to this handle because the operating system's state changed. This error typically occurs because the monitor PDO associated with this handle was removed or stopped, or a display mode change occurred. A display mode change occurs when Windows sends a WM_DISPLAYCHANGE message to applications
+      3223193056: This function can be used only if a program is running in the local console session. It cannot be used if a program is running on a remote desktop session or on a terminal server session
+      3223193057: This function cannot find an actual GDI display device that corresponds to the specified GDI display device name
+      3223193058: The function failed because the specified GDI display device was not attached to the Windows desktop
+      3223193059: This function does not support GDI mirroring display devices because GDI mirroring display devices do not have any physical monitors associated with them
+      3223193060: The function failed because an invalid pointer parameter was passed to it. A pointer parameter is invalid if it is null, is not correctly aligned, or points to an invalid address or to a kernel mode address
+      3223193061: This function failed because the GDI device passed to it did not have a monitor associated with it
+      3223193062: An array passed to the function cannot hold all of the data that the function must copy into the array
+      3223193063: An internal error caused an operation to fail
+      3223193064: The function failed because the current session is changing its type. This function cannot be called when the current session is changing its type
+      3223388160: The volume must be unlocked before it can be used
+      3223388161: The volume is fully decrypted and no key is available
+      3223388162: The control block for the encrypted volume is not valid
+      3223388163: Not enough free space remains on the volume to allow encryption
+      3223388164: The partition cannot be encrypted because the file system is not supported
+      3223388165: The file system is inconsistent. Run the Check Disk utility
+      3223388166: The file system does not extend to the end of the volume
+      3223388167: This operation cannot be performed while a file system is mounted on the volume
+      3223388168: BitLocker Drive Encryption is not included with this version of Windows
+      3223388169: The requested action was denied by the FVE control engine
+      3223388170: The data supplied is malformed
+      3223388171: The volume is not bound to the system
+      3223388172: The volume specified is not a data volume
+      3223388173: A read operation failed while converting the volume
+      3223388174: A write operation failed while converting the volume
+      3223388175: The control block for the encrypted volume was updated by another thread. Try again
+      3223388176: The volume encryption algorithm cannot be used on this sector size
+      3223388177: BitLocker recovery authentication failed
+      3223388178: The volume specified is not the boot operating system volume
+      3223388179: The BitLocker startup key or recovery password could not be read from external media
+      3223388180: The BitLocker startup key or recovery password file is corrupt or invalid
+      3223388181: The BitLocker encryption key could not be obtained from the startup key or the recovery password
+      3223388182: The TPM is disabled
+      3223388183: The authorization data for the SRK of the TPM is not zero
+      3223388184: The system boot information changed or the TPM locked out access to BitLocker encryption keys until the computer is restarted
+      3223388185: The BitLocker encryption key could not be obtained from the TPM
+      3223388186: The BitLocker encryption key could not be obtained from the TPM and PIN
+      3223388187: A boot application hash does not match the hash computed when BitLocker was turned on
+      3223388188: The Boot Configuration Data (BCD) settings are not supported or have changed because BitLocker was enabled
+      3223388189: Boot debugging is enabled. Run Windows Boot Configuration Data Store Editor (bcdedit.exe) to turn it off
+      3223388190: The BitLocker encryption key could not be obtained
+      3223388191: The metadata disk region pointer is incorrect
+      3223388192: The backup copy of the metadata is out of date
+      3223388193: No action was taken because a system restart is required
+      3223388194: No action was taken because BitLocker Drive Encryption is in RAW access mode
+      3223388195: BitLocker Drive Encryption cannot enter RAW access mode for this volume
+      3223388198: This feature of BitLocker Drive Encryption is not included with this version of Windows
+      3223388199: Group policy does not permit turning off BitLocker Drive Encryption on roaming data volumes
+      3223388200: Bitlocker Drive Encryption failed to recover from aborted conversion. This could be due to either all conversion logs being corrupted or the media being write-protected
+      3223388201: The requested virtualization size is too big
+      3223388208: The drive is too small to be protected using BitLocker Drive Encryption
+      3223453697: The callout does not exist
+      3223453698: The filter condition does not exist
+      3223453699: The filter does not exist
+      3223453700: The layer does not exist
+      3223453701: The provider does not exist
+      3223453702: The provider context does not exist
+      3223453703: The sublayer does not exist
+      3223453704: The object does not exist
+      3223453705: An object with that GUID or LUID already exists
+      3223453706: The object is referenced by other objects and cannot be deleted
+      3223453707: The call is not allowed from within a dynamic session
+      3223453708: The call was made from the wrong session and cannot be completed
+      3223453709: The call must be made from within an explicit transaction
+      3223453710: The call is not allowed from within an explicit transaction
+      3223453711: The explicit transaction has been forcibly canceled
+      3223453712: The session has been canceled
+      3223453713: The call is not allowed from within a read-only transaction
+      3223453714: The call timed out while waiting to acquire the transaction lock
+      3223453715: The collection of network diagnostic events is disabled
+      3223453716: The operation is not supported by the specified layer
+      3223453717: The call is allowed for kernel-mode callers only
+      3223453718: The call tried to associate two objects with incompatible lifetimes
+      3223453719: The object is built-in and cannot be deleted
+      3223453720: The maximum number of boot-time filters has been reached
+      3223453721: A notification could not be delivered because a message queue has reached maximum capacity
+      3223453722: The traffic parameters do not match those for the security association context
+      3223453723: The call is not allowed for the current security association state
+      3223453724: A required pointer is null
+      3223453725: An enumerator is not valid
+      3223453726: The flags field contains an invalid value
+      3223453727: A network mask is not valid
+      3223453728: An FWP_RANGE is not valid
+      3223453729: The time interval is not valid
+      3223453730: An array that must contain at least one element has a zero length
+      3223453731: The displayData.name field cannot be null
+      3223453732: The action type is not one of the allowed action types for a filter
+      3223453733: The filter weight is not valid
+      3223453734: A filter condition contains a match type that is not compatible with the operands
+      3223453735: An FWP_VALUE or FWPM_CONDITION_VALUE is of the wrong type
+      3223453736: An integer value is outside the allowed range
+      3223453737: A reserved field is nonzero
+      3223453738: A filter cannot contain multiple conditions operating on a single field
+      3223453739: A policy cannot contain the same keying module more than once
+      3223453740: The action type is not compatible with the layer
+      3223453741: The action type is not compatible with the sublayer
+      3223453742: The raw context or the provider context is not compatible with the layer
+      3223453743: The raw context or the provider context is not compatible with the callout
+      3223453744: The authentication method is not compatible with the policy type
+      3223453745: The Diffie-Hellman group is not compatible with the policy type
+      3223453746: An IKE policy cannot contain an Extended Mode policy
+      3223453747: The enumeration template or subscription will never match any objects
+      3223453748: The provider context is of the wrong type
+      3223453749: The parameter is incorrect
+      3223453750: The maximum number of sublayers has been reached
+      3223453751: The notification function for a callout returned an error
+      3223453752: The IPsec authentication configuration is not compatible with the authentication type
+      3223453753: The IPsec cipher configuration is not compatible with the cipher type
+      3223453756: A policy cannot contain the same auth method more than once
+      3223453952: The TCP/IP stack is not ready
+      3223453953: The injection handle is being closed by another thread
+      3223453954: The injection handle is stale
+      3223453955: The classify cannot be pended
+      3223519234: The binding to the network interface is being closed
+      3223519236: An invalid version was specified
+      3223519237: An invalid characteristics table was used
+      3223519238: Failed to find the network interface or the network interface is not ready
+      3223519239: Failed to open the network interface
+      3223519240: The network interface has encountered an internal unrecoverable failure
+      3223519241: The multicast list on the network interface is full
+      3223519242: An attempt was made to add a duplicate multicast address to the list
+      3223519243: At attempt was made to remove a multicast address that was never added
+      3223519244: The network interface aborted the request
+      3223519245: The network interface cannot process the request because it is being reset
+      3223519247: An attempt was made to send an invalid packet on a network interface
+      3223519248: The specified request is not a valid operation for the target device
+      3223519249: The network interface is not ready to complete this operation
+      3223519252: The length of the buffer submitted for this operation is not valid
+      3223519253: The data used for this operation is not valid
+      3223519254: The length of the submitted buffer for this operation is too small
+      3223519255: The network interface does not support this object identifier
+      3223519256: The network interface has been removed
+      3223519257: The network interface does not support this media type
+      3223519258: An attempt was made to remove a token ring group address that is in use by other components
+      3223519259: An attempt was made to map a file that cannot be found
+      3223519260: An error occurred while NDIS tried to map the file
+      3223519261: An attempt was made to map a file that is already mapped
+      3223519262: An attempt to allocate a hardware resource failed because the resource is used by another component
+      3223519263: The I/O operation failed because the network media is disconnected or the wireless access point is out of range
+      3223519266: The network address used in the request is invalid
+      3223519274: The offload operation on the network interface has been paused
+      3223519275: The network interface was not found
+      3223519276: The revision number specified in the structure is not supported
+      3223519277: The specified port does not exist on this network interface
+      3223519278: The current state of the specified port on this network interface does not support the requested operation
+      3223519279: The miniport adapter is in a lower power state
+      3223519419: The network interface does not support this request
+      3223523343: The TCP connection is not offloadable because of a local policy setting
+      3223523346: The TCP connection is not offloadable by the Chimney offload target
+      3223523347: The IP Path object is not in an offloadable state
+      3223527424: The wireless LAN interface is in auto-configuration mode and does not support the requested parameter change operation
+      3223527425: The wireless LAN interface is busy and cannot perform the requested operation
+      3223527426: The wireless LAN interface is power down and does not support the requested operation
+      3223527427: The list of wake on LAN patterns is full
+      3223527428: The list of low power protocol offloads is full
+      3224764417: The SPI in the packet does not match a valid IPsec SA
+      3224764418: The packet was received on an IPsec SA whose lifetime has expired
+      3224764419: The packet was received on an IPsec SA that does not match the packet characteristics
+      3224764420: The packet sequence number replay check failed
+      3224764421: The IPsec header and/or trailer in the packet is invalid
+      3224764422: The IPsec integrity check failed
+      3224764423: IPsec dropped a clear text packet
+      3224764424: IPsec dropped an incoming ESP packet in authenticated firewall mode.  This drop is benign
+      3224764425: IPsec dropped a packet due to DOS throttle
+      3224797184: IPsec Dos Protection matched an explicit block rule
+      3224797185: IPsec Dos Protection received an IPsec specific multicast packet which is not allowed
+      3224797186: IPsec Dos Protection received an incorrectly formatted packet
+      3224797187: IPsec Dos Protection failed to lookup state
+      3224797188: IPsec Dos Protection failed to create state because there are already maximum number of entries allowed by policy
+      3224797189: IPsec Dos Protection received an IPsec negotiation packet for a keying module which is not allowed by policy
+      3224797190: IPsec Dos Protection failed to create per internal IP ratelimit queue because there is already maximum number of queues allowed by policy
+      3224895579: The system does not support mirrored volumes
+      3224895580: The system does not support RAID-5 volumes
+      3225026580: A virtual disk support provider for the specified file was not found
+      3225026581: The specified disk is not a virtual disk
+      3225026582: The chain of virtual hard disks is inaccessible. The process has not been granted access rights to the parent virtual hard disk for the differencing disk
+      3225026583: The chain of virtual hard disks is corrupted. There is a mismatch in the virtual sizes of the parent virtual hard disk and differencing disk
+      3225026584: The chain of virtual hard disks is corrupted. A differencing disk is indicated in its own parent chain
+      3225026585: The chain of virtual hard disks is inaccessible. There was an error opening a virtual hard disk further up the chain
+
 # Documentation:
 # https://windowsbb.com/threads/256606/
+# SMB::StatusCode (base/protocols/smb/const-nt-status.zeek): https://docs.zeek.org/en/master/scripts/base/protocols/smb/consts.zeek.html
 #
 # Example Event Data:
 # <Event>

--- a/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4624.map
+++ b/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4624.map
@@ -49,6 +49,20 @@ Maps:
         Name: TargetLogonId
         Value: "/Event/EventData/Data[@Name=\"TargetLogonId\"]"
   -
+    Property: PayloadData4
+    PropertyValue: "AuthenticationPackageName: %AuthenticationPackageName%"
+    Values:
+      -
+        Name: AuthenticationPackageName
+        Value: "/Event/EventData/Data[@Name=\"AuthenticationPackageName\"]"
+  -
+    Property: PayloadData5
+    PropertyValue: "LogonProcessName: %LogonProcessName%"
+    Values:
+      -
+        Name: LogonProcessName
+        Value: "/Event/EventData/Data[@Name=\"LogonProcessName\"]"
+  -
     Property: ExecutableInfo
     PropertyValue: "%ProcessName%"
     Values:

--- a/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4648.map
+++ b/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4648.map
@@ -55,6 +55,13 @@ Maps:
       -
         Name: ProcessId
         Value: "/Event/EventData/Data[@Name=\"ProcessId\"]"
+  -
+    Property: PayloadData4
+    PropertyValue: "TargetInfo: %TargetInfo%"
+    Values:
+      -
+        Name: TargetInfo
+        Value: "/Event/EventData/Data[@Name=\"TargetInfo\"]"
 
 # Documentation:
 # https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=4648

--- a/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_5379.map
+++ b/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_5379.map
@@ -39,7 +39,20 @@ Maps:
       -
         Name: SubjectLogonId
         Value: "/Event/EventData/Data[@Name=\"SubjectLogonId\"]"
-
+  -
+    Property: PayloadData4
+    PropertyValue: "CountOfCredentialsReturned: %CountOfCredentialsReturned%"
+    Values:
+      -
+        Name: CountOfCredentialsReturned
+        Value: "/Event/EventData/Data[@Name=\"CountOfCredentialsReturned\"]"
+  -
+    Property: PayloadData6
+    PropertyValue: "ActivityID: %ActivityID%"
+    Values:
+      -
+        Name: ActivityID
+        Value: "/Event/System/Correlation/@ActivityID"
 
 # Documentation:
 # https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=5379


### PR DESCRIPTION
## Description

- **1006** - added `Location` to the map: if a VHD/ISO is mounted with Explorer, this field contains the full path of the file. `Executable Info` was the only free remaining column that could be used. I provided an additional example event.
- **4624** - added `AuthenticationPackageName `and `LogonProcessName`: they can be useful for quickly finding NTLM or Kerberos authentications.
- **4648** - added `TargetInfo`: when a `TargetServerName` is accessed via SMB, it contains the value `cifs/`TargetServerName.
- **5379** - added `CountOfCredentialsReturned `and `ActivityID`
- **30807** - added lookups for `Status` codes. I retrieved the SMB::StatusCode values/descriptions from the Zeek project. Documentation updated.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [ ] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [ ] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [X] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [X] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [ ] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
