### PR TITLE
New maps for NTDS/Computer account creation/MSSQLSERVER events

### DIFF
--- a/evtx/Maps/Application_ESENT_325.map
+++ b/evtx/Maps/Application_ESENT_325.map
@@ -1,0 +1,38 @@
+Author: Gabriele Zambelli @gazambelli
+Description: NTDS the database engine created a new database
+EventId: 325
+Channel: Application
+Provider: ESENT
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "Database: %Database%"
+    Values:
+      -
+        Name: Database
+        Value: "/Event/EventData/Data"
+        Refine: "[a-zA-Z]{1}:.*\\.[a-zA-Z]{3,5}"
+
+# Documentation:
+# Windows Events Attack Samples: https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES
+# https://blog.menasec.net/2019/11/forensics-traces-of-ntdsdit-dumping.html
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="ESENT" />
+#     <EventID Qualifiers="0">325</EventID>
+#     <Level>4</Level>
+#     <Task>1</Task>
+#     <Keywords>0x80000000000000</Keywords>
+#     <TimeCreated SystemTime="2019-11-26 23:55:00.0000000" />
+#     <EventRecordID>1970</EventRecordID>
+#     <Channel>Application</Channel>
+#     <Computer>DC1.insecurebank.local</Computer>
+#     <Security />
+#   </System>
+#   <EventData>
+#     <Data>NTDS, 3392, 2, C:\Users\bob\Desktop\test\Folder\ntds\Active Directory\ntds.dit, 0, [1] 0.000, [2] 0.000, [3] 0.000, [4] 0.047, [5] 0.000, [6] 0.000, [7] 0.000, [8] 0.000, [9] 0.000, [10] 0.000, [11] 0.000.</Data>
+#     <Binary></Binary>
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Application_ESENT_326.map
+++ b/evtx/Maps/Application_ESENT_326.map
@@ -1,0 +1,39 @@
+Author: Gabriele Zambelli @gazambelli
+Description: NTDS the database engine attached a database
+EventId: 326
+Channel: Application
+Provider: ESENT
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "Database: %Database%"
+    Values:
+      -
+        Name: Database
+        Value: "/Event/EventData/Data"
+        Refine: "[a-zA-Z]{1}:.*\\.[a-zA-Z]{3,5}"
+
+# Documentation:
+# Windows Events Attack Samples: https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES
+# https://blog.menasec.net/2019/11/forensics-traces-of-ntdsdit-dumping.html
+# https://docs.microsoft.com/en-us/troubleshoot/windows-server/performance/esent-event-327-326
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="ESENT" />
+#     <EventID Qualifiers="0">326</EventID>
+#     <Level>4</Level>
+#     <Task>1</Task>
+#     <Keywords>0x80000000000000</Keywords>
+#     <TimeCreated SystemTime="2019-11-26 23:55:00.0000000" />
+#     <EventRecordID>1969</EventRecordID>
+#     <Channel>Application</Channel>
+#     <Computer>DC1.insecurebank.local</Computer>
+#     <Security />
+#   </System>
+#   <EventData>
+#     <Data>NTDS, 3392, 1, C:\$SNAP_201911270054_VOLUMEC$\Windows\NTDS\ntds.dit, 0, [1] 0.000, [2] 0.000, [3] 0.000, [4] 0.000, [5] 0.000, [6] 0.000, [7] 0.000, [8] 0.000, [9] 0.000, [10] 0.000, [11] 0.000, [12] 0.000., 1 0</Data>
+#     <Binary></Binary>
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Application_ESENT_327.map
+++ b/evtx/Maps/Application_ESENT_327.map
@@ -1,0 +1,39 @@
+Author: Gabriele Zambelli @gazambelli
+Description: NTDS the database engine detached a database
+EventId: 327
+Channel: Application
+Provider: ESENT
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "Database: %Database%"
+    Values:
+      -
+        Name: Database
+        Value: "/Event/EventData/Data"
+        Refine: "[a-zA-Z]{1}:.*\\.[a-zA-Z]{3,5}"
+
+# Documentation:
+# Windows Events Attack Samples: https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES
+# https://blog.menasec.net/2019/11/forensics-traces-of-ntdsdit-dumping.html
+# https://docs.microsoft.com/en-us/troubleshoot/windows-server/performance/esent-event-327-326
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="ESENT" />
+#     <EventID Qualifiers="0">327</EventID>
+#     <Level>4</Level>
+#     <Task>1</Task>
+#     <Keywords>0x80000000000000</Keywords>
+#     <TimeCreated SystemTime="2019-11-26 23:55:02.0000000" />
+#     <EventRecordID>1971</EventRecordID>
+#     <Channel>Application</Channel>
+#     <Computer>DC1.insecurebank.local</Computer>
+#     <Security />
+#   </System>
+#   <EventData>
+#     <Data>NTDS, 3392, 2, C:\Users\bob\Desktop\test\Folder\ntds\Active Directory\ntds.dit, 0, [1] 0.000, [2] 0.000, [3] 0.000, [4] 0.110, [5] 0.000, [6] 0.015, [7] 0.000, [8] 0.000, [9] 0.000, [10] 0.266, [11] 0.000, [12] 0.000., 0 0</Data>
+#     <Binary></Binary>
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Application_MSSQLSERVER_15457.map
+++ b/evtx/Maps/Application_MSSQLSERVER_15457.map
@@ -1,0 +1,47 @@
+Author: Gabriele Zambelli @gazambelli
+Description: MSSQLSERVER Configuration change
+EventId: 15457
+Channel: Application
+Provider: MSSQLSERVER
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "Configuration option %Option% changed from %ChangedFrom% to %ChangedTo%"
+    Values:
+      -
+        Name: Option
+        Value: "/Event/EventData/Data"
+        Refine: "^[a-zA-Z0-9 _-]{3,50}(?=,)"
+      -
+        Name: ChangedFrom
+        Value: "/Event/EventData/Data"
+        Refine: "(?<=, ).*(?=,)"
+      -
+        Name: ChangedTo
+        Value: "/Event/EventData/Data"
+        Refine: "(?<=, )[0-9]{1}$"
+
+
+# Documentation:
+# Windows Events Attack Samples: https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES
+# Detecting High Risk Behavior via Basic Event Log Analysis: https://github.com/NetSPI/PowerUpSQL/wiki/SQL-Server-Detective-Control-Cheat-Sheet#3
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="MSSQLSERVER" />
+#     <EventID Qualifiers="16384">15457</EventID>
+#     <Level>4</Level>
+#     <Task>2</Task>
+#     <Keywords>0x80000000000000</Keywords>
+#     <TimeCreated SystemTime="2019-11-04 09:27:26.1586215" />
+#     <EventRecordID>9692</EventRecordID>
+#     <Channel>Application</Channel>
+#     <Computer>MSEDGEWIN10</Computer>
+#     <Security />
+#   </System>
+#   <EventData>
+#     <Data>xp_cmdshell, 0, 1</Data>
+#     <Binary>61-3C-00-00-0A-00-00-00-0C-00-00-00-4D-00-53-00-45-00-44-00-47-00-45-00-57-00-49-00-4E-00-31-00-30-00-00-00-07-00-00-00-6D-00-61-00-73-00-74-00-65-00-72-00-00-00</Binary>
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Application_MSSQLSERVER_18456.map
+++ b/evtx/Maps/Application_MSSQLSERVER_18456.map
@@ -1,0 +1,56 @@
+Author: Gabriele Zambelli @gazambelli
+Description: MSSQLSERVER Login failed
+EventId: 18456
+Channel: Application
+Provider: MSSQLSERVER
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "Target: %User%"
+    Values:
+      -
+        Name: User
+        Value: "/Event/EventData/Data"
+        Refine: "^[a-zA-Z0-9_#-]{2,50}(?=,)"
+  -
+    Property: PayloadData2
+    PropertyValue: "%Reason%"
+    Values:
+      -
+        Name: Reason
+        Value: "/Event/EventData/Data"
+        Refine: "Reason.*(?=,)"
+  -
+    Property: PayloadData3
+    PropertyValue: "%Client%"
+    Values:
+      -
+        Name: Client
+        Value: "/Event/EventData/Data"
+        Refine: "CLIENT.*(?=])"
+
+
+# Documentation:
+# Windows Events Attack Samples: https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES
+# Detecting High Risk Behavior via Basic Event Log Analysis: https://github.com/NetSPI/PowerUpSQL/wiki/SQL-Server-Detective-Control-Cheat-Sheet
+# https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-18456-database-engine-error?view=sql-server-ver16
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="MSSQLSERVER" />
+#     <EventID Qualifiers="49152">18456</EventID>
+#     <Level>0</Level>
+#     <Task>4</Task>
+#     <Keywords>0x90000000000000</Keywords>
+#     <TimeCreated SystemTime="2019-11-04 13:46:01.2798252" />
+#     <EventRecordID>13035</EventRecordID>
+#     <Channel>Application</Channel>
+#     <Computer>MSEDGEWIN10</Computer>
+#     <Security />
+#   </System>
+#   <EventData>
+#     <Data>root,  Reason: Password did not match that for the login provided.,  [CLIENT: 10.0.2.17]</Data>
+#     <Binary>18-48-00-00-0E-00-00-00-0C-00-00-00-4D-00-53-00-45-00-44-00-47-00-45-00-57-00-49-00-4E-00-31-00-30-00-00-00-07-00-00-00-6D-00-61-00-73-00-74-00-65-00-72-00-00-00</Binary>
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Application_MSSQLSERVER_33205.map
+++ b/evtx/Maps/Application_MSSQLSERVER_33205.map
@@ -1,0 +1,41 @@
+Author: Gabriele Zambelli @gazambelli
+Description: MSSQLSERVER Audit event
+EventId: 33205
+Channel: Application
+Provider: MSSQLSERVER
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "Raw Audit Event: %AuditEvent%"
+    Values:
+      -
+        Name: AuditEvent
+        Value: "/Event/EventData/Data"
+
+
+# Documentation:
+# Windows Events Attack Samples: https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES
+# Detecting High Risk Behavior via Basic Event Log Analysis: https://github.com/NetSPI/PowerUpSQL/wiki/SQL-Server-Detective-Control-Cheat-Sheet
+# Understanding a sample SQL audit event: https://www.ultimatewindowssecurity.com/sqlserver/auditlog/sampleevent.aspx
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="MSSQLSERVER" />
+#     <EventID Qualifiers="16384">33205</EventID>
+#     <Level>0</Level>
+#     <Task>5</Task>
+#     <Keywords>0xA0000000000000</Keywords>
+#     <TimeCreated SystemTime="2019-11-04 09:27:26.3150666" />
+#     <EventRecordID>9693</EventRecordID>
+#     <Channel>Application</Channel>
+#     <Computer>MSEDGEWIN10</Computer>
+#     <Security />
+#   </System>
+#   <EventData>
+#     <Data>audit_schema_version:1 event_time:2019-11-04 09:27:26.1750932 sequence_number:1 action_id:EX  succeeded:true is_column_permission:false session_id:58 server_principal_id:266 database_principal_id:1 target_server_principal_id:0 target_database_principal_id:0 object_id:-1008137134 user_defined_event_id:0 transaction_id:14356 class_type:X duration_milliseconds:0 response_rows:0 affected_rows:0 client_ip:10.0.2.17 permission_bitmask:00000000000000000000000000000020 sequence_group_id:AE51063D-49C6-4990-A00D-6A3833CFECA0 session_server_principal_name:root server_principal_name:root server_principal_sid:8867c003d7407345abb6e4ed81382626 database_principal_name:dbo target_server_principal_name: target_server_principal_sid: target_database_principal_name: server_instance_name:MSEDGEWIN10 database_name:master schema_name:sys object_name:xp_cmdshell statement:EXEC master..xp_cmdshell 'Whoami' additional_information: user_defined_information: application_name:.Net SqlClient Data Provider
+# </Data>
+#     <Binary></Binary>
+#   </EventData>
+# </Event>
+# <Event>

--- a/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4741.map
+++ b/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4741.map
@@ -1,0 +1,121 @@
+Author: Gabriele Zambelli @gazambelli
+Description: A computer account was created
+EventId: 4741
+Channel: Security
+Provider: Microsoft-Windows-Security-Auditing
+Maps:
+  -
+    Property: UserName
+    PropertyValue: "%SubjectDomainName%\\%SubjectUserName%"
+    Values:
+      -
+        Name: SubjectUserName
+        Value: "/Event/EventData/Data[@Name=\"SubjectUserName\"]"
+      -
+        Name: SubjectDomainName
+        Value: "/Event/EventData/Data[@Name=\"SubjectDomainName\"]"
+  -
+    Property: PayloadData1
+    PropertyValue: "Target: %TargetDomainName%\\%TargetUserName% (%TargetSid%)"
+    Values:
+      -
+        Name: TargetDomainName
+        Value: "/Event/EventData/Data[@Name=\"TargetDomainName\"]"
+      -
+        Name: TargetUserName
+        Value: "/Event/EventData/Data[@Name=\"TargetUserName\"]"
+      -
+        Name: TargetSid
+        Value: "/Event/EventData/Data[@Name=\"TargetSid\"]"
+  -
+    Property: PayloadData2
+    PropertyValue: "PasswordLastSet: %PasswordLastSet%"
+    Values:
+      -
+        Name: PasswordLastSet
+        Value: "/Event/EventData/Data[@Name=\"PasswordLastSet\"]"
+  -
+    Property: PayloadData3
+    PropertyValue: "LogonID: %SubjectLogonId%"
+    Values:
+      -
+        Name: SubjectLogonId
+        Value: "/Event/EventData/Data[@Name=\"SubjectLogonId\"]"
+  -
+    Property: PayloadData4
+    PropertyValue: "PrimaryGroupId: %PrimaryGroupId%"
+    Values:
+      -
+        Name: PrimaryGroupId
+        Value: "/Event/EventData/Data[@Name=\"PrimaryGroupId\"]"
+  -
+    Property: PayloadData5
+    PropertyValue: "DnsHostName: %DnsHostName%"
+    Values:
+      -
+        Name: DnsHostName
+        Value: "/Event/EventData/Data[@Name=\"DnsHostName\"]"
+
+Lookups:
+  -
+    Name: PrimaryGroupId
+    Default: Unknown code
+    Values:
+      515: Domain Computers
+      516: Domain Controllers
+      521: Read-only Domain Controllers
+
+
+# Documentation:
+# Windows Events Attack Samples: https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES
+# https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4741
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="Microsoft-Windows-Security-Auditing" Guid="54849625-5478-4994-a5ba-3e3b0328c30d" />
+#     <EventID>4741</EventID>
+#     <Version>0</Version>
+#     <Level>0</Level>
+#     <Task>13825</Task>
+#     <Opcode>0</Opcode>
+#     <Keywords>0x8020000000000000</Keywords>
+#     <TimeCreated SystemTime="2021-12-12 17:57:52.3136732" />
+#     <EventRecordID>2982085</EventRecordID>
+#     <Correlation />
+#     <Execution ProcessID="624" ThreadID="3652" />
+#     <Channel>Security</Channel>
+#     <Computer>01566s-win16-ir.threebeesco.com</Computer>
+#     <Security />
+#   </System>
+#   <EventData>
+#     <Data Name="TargetUserName">DC012$</Data>
+#     <Data Name="TargetDomainName">3B</Data>
+#     <Data Name="TargetSid">S-1-5-21-308926384-506822093-3341789130-220105</Data>
+#     <Data Name="SubjectUserSid">S-1-5-21-308926384-506822093-3341789130-101606</Data>
+#     <Data Name="SubjectUserName">lgrove</Data>
+#     <Data Name="SubjectDomainName">3B</Data>
+#     <Data Name="SubjectLogonId">0x738AE4</Data>
+#     <Data Name="PrivilegeList">-</Data>
+#     <Data Name="SamAccountName">DC012$</Data>
+#     <Data Name="DisplayName">-</Data>
+#     <Data Name="UserPrincipalName">-</Data>
+#     <Data Name="HomeDirectory">-</Data>
+#     <Data Name="HomePath">-</Data>
+#     <Data Name="ScriptPath">-</Data>
+#     <Data Name="ProfilePath">-</Data>
+#     <Data Name="UserWorkstations">-</Data>
+#     <Data Name="PasswordLastSet">12/12/2021 9:57:52 AM</Data>
+#     <Data Name="AccountExpires">%%1794</Data>
+#     <Data Name="PrimaryGroupId">515</Data>
+#     <Data Name="AllowedToDelegateTo">-</Data>
+#     <Data Name="OldUacValue">0x0</Data>
+#     <Data Name="NewUacValue">0x80</Data>
+#     <Data Name="UserAccountControl">, %%2087</Data>
+#     <Data Name="UserParameters">-</Data>
+#     <Data Name="SidHistory">-</Data>
+#     <Data Name="LogonHours">%%1793</Data>
+#     <Data Name="DnsHostName">DC012.threebeesco.com</Data>
+#     <Data Name="ServicePrincipalNames">, HOST/DC012.threebeesco.com, RestrictedKrbHost/DC012.threebeesco.com, HOST/DC012, RestrictedKrbHost/DC012</Data>
+#   </EventData>
+# </Event>


### PR DESCRIPTION
## Description

New maps for these events: 

- **325**: NTDS the database engine created a new database
- **326**: NTDS the database engine attached a database
- **327**: NTDS the database engine detached a database
- **4741**: A computer account was created
- **15457**: MSSQLSERVER Configuration change
- **18456**: MSSQLSERVER Login failed
- **33205**: MSSQLSERVER Audit event

Test data used: [Windows EVTX Samples](https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES)

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [X] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [X] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [X] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
