### PR TITLE
replaced deadlink

### DIFF
--- a/evtx/Maps/Microsoft-Windows-PowerShell-Operational_Microsoft-Windows-PowerShell_4103.map
+++ b/evtx/Maps/Microsoft-Windows-PowerShell-Operational_Microsoft-Windows-PowerShell_4103.map
@@ -61,7 +61,7 @@ Maps:
         Value: "/Event/EventData/Data[@Name=\"Payload\"]"
 
 # Documentation:
-# https://github.com/OTRF/OSSEM/blob/master/data_dictionaries/windows/powershell/events/event-4103.md
+# https://github.com/OTRF/OSSEM-DD/blob/afd9b27897346dfa3b3f43d2d403c3f5c5f86214/windows/powershell/events/event-4103.yml
 # https://github.com/nasbench/EVTX-ETW-Resources/blob/main/ETWProvidersCSVs/Internal/Microsoft-Windows-PowerShell.csv
 #
 # Example Event Data:


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [ ] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [ ] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [ ] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [ ] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [ ] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
