### PR TITLE
Fix MS-W-TS-Gatway-Op-* RemoteHost field

### DIFF
--- a/evtx/Maps/Microsoft-Windows-TerminalServices-Gateway-Operational_Microsoft-Windows-TerminalServices-Gateway_200.map
+++ b/evtx/Maps/Microsoft-Windows-TerminalServices-Gateway-Operational_Microsoft-Windows-TerminalServices-Gateway_200.map
@@ -13,11 +13,11 @@ Maps:
         Value: "/Event/UserData/EventInfo/Username"
   -
     Property: RemoteHost
-    PropertyValue: "%Address%"
+    PropertyValue: "%IpAddress%"
     Values:
       -
-        Name: Address
-        Value: "/Event/UserData/EventXML/Address"
+        Name: IpAddress
+        Value: "/Event/UserData/EventInfo/IpAddress"
   -
     Property: PayloadData1
     PropertyValue: "%Username% on client computer %IpAddress% met resource authorization policy requirements and was therefore authorized to access the TS Gateway server"

--- a/evtx/Maps/Microsoft-Windows-TerminalServices-Gateway-Operational_Microsoft-Windows-TerminalServices-Gateway_300.map
+++ b/evtx/Maps/Microsoft-Windows-TerminalServices-Gateway-Operational_Microsoft-Windows-TerminalServices-Gateway_300.map
@@ -13,11 +13,11 @@ Maps:
         Value: "/Event/UserData/EventInfo/Username"
   -
     Property: RemoteHost
-    PropertyValue: "%Address%"
+    PropertyValue: "%IpAddress%"
     Values:
       -
-        Name: Address
-        Value: "/Event/UserData/EventXML/Address"
+        Name: IpAddress
+        Value: "/Event/UserData/EventInfo/IpAddress"
   -
     Property: PayloadData1
     PropertyValue: "%Username% on client computer %IpAddress% met resource authorization policy requirements and was therefore authorized to connect to %Resource%"

--- a/evtx/Maps/Microsoft-Windows-TerminalServices-Gateway-Operational_Microsoft-Windows-TerminalServices-Gateway_302.map
+++ b/evtx/Maps/Microsoft-Windows-TerminalServices-Gateway-Operational_Microsoft-Windows-TerminalServices-Gateway_302.map
@@ -13,11 +13,11 @@ Maps:
         Value: "/Event/UserData/EventInfo/Username"
   -
     Property: RemoteHost
-    PropertyValue: "%Address%"
+    PropertyValue: "%IpAddress%"
     Values:
       -
-        Name: Address
-        Value: "/Event/UserData/EventXML/Address"
+        Name: IpAddress
+        Value: "/Event/UserData/EventInfo/IpAddress"
   -
     Property: PayloadData1
     PropertyValue: "%Username% on client computer %IpAddress% connected to %Resource%"

--- a/evtx/Maps/Microsoft-Windows-TerminalServices-Gateway-Operational_Microsoft-Windows-TerminalServices-Gateway_303.map
+++ b/evtx/Maps/Microsoft-Windows-TerminalServices-Gateway-Operational_Microsoft-Windows-TerminalServices-Gateway_303.map
@@ -13,11 +13,11 @@ Maps:
         Value: "/Event/UserData/EventInfo/Username"
   -
     Property: RemoteHost
-    PropertyValue: "%Address%"
+    PropertyValue: "%IpAddress%"
     Values:
       -
-        Name: Address
-        Value: "/Event/UserData/EventXML/Address"
+        Name: IpAddress
+        Value: "/Event/UserData/EventInfo/IpAddress"
   -
     Property: PayloadData1
     PropertyValue: "%Username% on client computer %IpAddress% disconnected from %Resource%"

--- a/evtx/Maps/Microsoft-Windows-TerminalServices-Gateway-Operational_Microsoft-Windows-TerminalServices-Gateway_312.map
+++ b/evtx/Maps/Microsoft-Windows-TerminalServices-Gateway-Operational_Microsoft-Windows-TerminalServices-Gateway_312.map
@@ -13,11 +13,11 @@ Maps:
         Value: "/Event/UserData/EventInfo/Username"
   -
     Property: RemoteHost
-    PropertyValue: "%Address%"
+    PropertyValue: "%IpAddress%"
     Values:
       -
-        Name: Address
-        Value: "/Event/UserData/EventXML/Address"
+        Name: IpAddress
+        Value: "/Event/UserData/EventInfo/IpAddress"
   -
     Property: PayloadData1
     PropertyValue: "%Username% on client computer %IpAddress% has initiated an outbound connection that has yet to be authenticated"

--- a/evtx/Maps/Microsoft-Windows-TerminalServices-Gateway-Operational_Microsoft-Windows-TerminalServices-Gateway_313.map
+++ b/evtx/Maps/Microsoft-Windows-TerminalServices-Gateway-Operational_Microsoft-Windows-TerminalServices-Gateway_313.map
@@ -13,11 +13,11 @@ Maps:
         Value: "/Event/UserData/EventInfo/Username"
   -
     Property: RemoteHost
-    PropertyValue: "%Address%"
+    PropertyValue: "%IpAddress%"
     Values:
       -
-        Name: Address
-        Value: "/Event/UserData/EventXML/Address"
+        Name: IpAddress
+        Value: "/Event/UserData/EventInfo/IpAddress"
   -
     Property: PayloadData1
     PropertyValue: "%Username% on client computer %IpAddress% has initiated an inbound connection that has yet to be authenticated"


### PR DESCRIPTION
## Description

I believe that there was an oversight during the creation of the `Microsoft-Windows-TerminalServices-Gateway/Operational`  mapping files. The current mappings do not populate the `RemoteHost` field even though it is included in the mapping.

The maps section of each of the files currently look like this:

    Maps:
      -
        Property: UserName
        PropertyValue: "%Username%"
        Values:
          -
            Name: Username
            Value: "/Event/UserData/EventInfo/Username"
      -
        Property: RemoteHost
        PropertyValue: "%Address%"
        Values:
          -
            Name: Address
            Value: "/Event/UserData/EventXML/Address"


Notice that the `Username` is sourced from `.../EventInfo/Username` but that the `RemoteHost` is sourced from `.../EventXML/Address`.

When reviewing the Example Data provided in the map, there is no `EventXML` key nor `Address` key:

```
# Example Event Data:
# <Event>
#   <System>
#     <Provider Name="Microsoft-Windows-TerminalServices-Gateway" Guid="4d5ae6a1-c7c8-4e6d-b840-4d8080b42e1b" />
#     <EventID>200</EventID>
#     <Version>0</Version>
#     <Level>4</Level>
#     <Task>5</Task>
#     <Opcode>30</Opcode>
#     <Keywords>0x4020000001000000</Keywords>
#     <TimeCreated SystemTime="2021-05-16 20:13:17.4272057" />
#     <EventRecordID>1251305</EventRecordID>
#     <Correlation ActivityID="3fb80caa-2356-43c8-9991-b852526f2500" />
#     <Execution ProcessID="2040" ThreadID="1888" />
#     <Channel>Microsoft-Windows-TerminalServices-Gateway/Operational</Channel>
#     <Computer>HOSTNAME.domain.com</Computer>
#     <Security UserID="S-1-5-20" />
#   </System>
#   <UserData>
#     <EventInfo>
#       <Username>DOMAIN\username</Username>
#       <IpAddress>72.16.2.13</IpAddress>
#       <AuthType>NTLM</AuthType>
#       <Resource></Resource>
#       <ConnectionProtocol>HTTP</ConnectionProtocol>
#       <ErrorCode>0</ErrorCode>
#     </EventInfo>
#   </UserData>
# </Event>
```

It seems that this was probably just a copy/paste error from the other Terminal Services mappings, which _do_ have `.../EventXML/Address`. [Example](https://github.com/EricZimmerman/evtx/blob/15df0ec21cc41356cb12731679259670ad1d16aa/evtx/Maps/Microsoft-Windows-TerminalServices-LocalSessionManager-Operational_Microsoft-Windows-TerminalServices-LocalSessionManager_22.map#L50-L54)

I reviewed the references from the 6 affected mapping files and did not see any indications that `.../EventXML/Address` was every used.

This pull request updates the `RemoteHost` property to pull from `.../EventInfo/IpAddress` to match what seems to be the correct schema.

I have confirmed with live data that the property is not populated before the changes but is populated for all 6 mappings after the changes, but I am not able to share the data.

Thanks for your time and providing your tools to the community.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [ ] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [ ] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [X] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [ ] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format
