### PR TITLE
remove spaces to be consistent with System:1

### DIFF
--- a/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4616.map
+++ b/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_4616.map
@@ -26,14 +26,14 @@ Maps:
         Value: "/Event/EventData/Data[@Name=\"ProcessName\"]"
   -
     Property: PayloadData1
-    PropertyValue: "Previous Time: %PreviousTime%"
+    PropertyValue: "PreviousTime: %PreviousTime%"
     Values:
       -
         Name: PreviousTime
         Value: "/Event/EventData/Data[@Name=\"PreviousTime\"]"
   -
     Property: PayloadData2
-    PropertyValue: "New Time: %NewTime%"
+    PropertyValue: "NewTime: %NewTime%"
     Values:
       -
         Name: NewTime


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [ ] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [ ] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [ ] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [ ] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [ ] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
