### PR TITLE
add CiscoSecureEndpoint Maps (100,1300,1310)

### DIFF
--- a/evtx/Maps/CiscoSecureEndpoint-Events_CiscoSecureEndpoint_100.map
+++ b/evtx/Maps/CiscoSecureEndpoint-Events_CiscoSecureEndpoint_100.map
@@ -1,0 +1,71 @@
+Author: Andrew Rathbun
+Description: Cisco Secure Endpoint Detection
+EventId: 100
+Channel: "CiscoSecureEndpoint/Events"
+Provider: CiscoSecureEndpoint
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "ThreatModule: %ThreatModule%"
+    Values:
+      -
+        Name: ThreatModule
+        Value: "/Event/EventData/Data[@Name=\"AttackInfo\"]"
+        Refine: "(?<=\"threat_module_s\":\")(.*?)(?=\",\"threat_sub_module_s\")"
+  -
+    Property: PayloadData2
+    PropertyValue: "ParentProcessName: %ParentProcessName%"
+    Values:
+      -
+        Name: ParentProcessName
+        Value: "/Event/EventData/Data[@Name=\"ParentProcessName\"]"
+
+  -
+    Property: ExecutableInfo
+    PropertyValue: "%ProcessName%"
+    Values:
+      -
+        Name: ProcessName
+        Value: "/Event/EventData/Data[@Name=\"ProcessName\"]"
+
+  -
+    Property: UserName
+    PropertyValue: "%UserName%"
+    Values:
+      -
+        Name: UserName
+        Value: "/Event/EventData/Data[@Name=\"AttackInfo\"]"
+        Refine: "(?<=\"u\":\")(.*?)(?=\")"
+
+# Documentation:
+# N/A
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="CiscoSecureEndpoint" Guid="0643104d-3c79-4ed5-9ed4-cd8e803fea9c" />
+#     <EventID>100</EventID>
+#     <Version>1</Version>
+#     <Level>4</Level>
+#     <Task>10</Task>
+#     <Opcode>0</Opcode>
+#     <Keywords>0x8000000000000000</Keywords>
+#     <TimeCreated SystemTime="2022-03-05 19:12:53.1234567" />
+#     <EventRecordID>19</EventRecordID>
+#     <Correlation />
+#     <Execution ProcessID="1234" ThreadID="5678" />
+#     <Channel>CiscoSecureEndpoint/Events</Channel>
+#     <Computer>HOSTNAME.domain.com</Computer>
+#     <Security UserID="S-1-5-18" />
+#   </System>
+#   <EventData>
+#    <Data Name="PID">1548</Data>
+#    <Data Name="TimeStamp">1675861234</Data>
+#    <Data Name="ProcessName">C:\programdata\evil.exe</Data>
+#    <Data Name="AttackInfo">{"afps":"C:\\programdata\\evil.exe","ams":"kernel32.dll","at":"2022-10-08 12:13:33","bas":"0x00007FFA54171234","edvs":"5.3.11.13","sfs":[""],"sus":[""],"threat_module_s":"Shellcode","threat_sub_module_s":"PEB","u":"username@DOMAIN"}</Data>
+#    <Data Name="SuspiciousFiles"></Data>
+#    <Data Name="ParentProcessName">C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</Data>
+#    <Data Name="ParentProcessPID">1234</Data>
+#    <Data Name="ScriptControlBadDll"></Data>
+#   </EventData>
+# </Event>

--- a/evtx/Maps/CiscoSecureEndpoint-Events_CiscoSecureEndpoint_1300.map
+++ b/evtx/Maps/CiscoSecureEndpoint-Events_CiscoSecureEndpoint_1300.map
@@ -1,0 +1,64 @@
+Author: Andrew Rathbun
+Description: Cisco Secure Endpoint Detection
+EventId: 1300
+Channel: "CiscoSecureEndpoint/Events"
+Provider: CiscoSecureEndpoint
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "DetectionName: %DetectionName%"
+    Values:
+      -
+        Name: DetectionName
+        Value: "/Event/EventData/Data[@Name=\"DetectionName\"]"
+  -
+    Property: PayloadData2
+    PropertyValue: "ParentName: %ParentName%"
+    Values:
+      -
+        Name: ParentName
+        Value: "/Event/EventData/Data[@Name=\"ParentName\"]"
+  -
+    Property: PayloadData3
+    PropertyValue: "DetectionId: %DetectionId%"
+    Values:
+      -
+        Name: DetectionId
+        Value: "/Event/EventData/Data[@Name=\"DetectionId\"]"
+  -
+    Property: ExecutableInfo
+    PropertyValue: "%DetectedFilePath%"
+    Values:
+      -
+        Name: DetectedFilePath
+        Value: "/Event/EventData/Data[@Name=\"DetectedFilePath\"]"
+
+# Documentation:
+# N/A
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="CiscoSecureEndpoint" Guid="0643104d-3c79-4ed5-9ed4-cd8e803fea9c" />
+#     <EventID>1300</EventID>
+#     <Version>1</Version>
+#     <Level>4</Level>
+#     <Task>10</Task>
+#     <Opcode>0</Opcode>
+#     <Keywords>0x8000000000000000</Keywords>
+#     <TimeCreated SystemTime="2022-03-05 19:12:53.1234567" />
+#     <EventRecordID>19</EventRecordID>
+#     <Correlation />
+#     <Execution ProcessID="1234" ThreadID="5678" />
+#     <Channel>CiscoSecureEndpoint/Events</Channel>
+#     <Computer>HOSTNAME.domain.com</Computer>
+#     <Security UserID="S-1-5-18" />
+#   </System>
+#   <EventData>
+#     <Data Name="DetectionName">IL:Trojan.MSILZilla.6459</Data>
+#     <Data Name="DetectionId">719612345678907012</Data>
+#     <Data Name="ParentName">powershell.exe</Data>
+#     <Data Name="DetectedFilePath">C:\ProgramData\evil.exe</Data>
+#     <Data Name="DetectionEngine">64</Data>
+#   </EventData>
+# </Event>

--- a/evtx/Maps/CiscoSecureEndpoint-Events_CiscoSecureEndpoint_1310.map
+++ b/evtx/Maps/CiscoSecureEndpoint-Events_CiscoSecureEndpoint_1310.map
@@ -1,0 +1,47 @@
+Author: Andrew Rathbun
+Description: Cisco Secure Endpoint Detection
+EventId: 1310
+Channel: "CiscoSecureEndpoint/Events"
+Provider: CiscoSecureEndpoint
+Maps:
+  -
+    Property: PayloadData3
+    PropertyValue: "DetectionId: %DetectionId%"
+    Values:
+      -
+        Name: DetectionId
+        Value: "/Event/EventData/Data[@Name=\"DetectionId\"]"
+  -
+    Property: ExecutableInfo
+    PropertyValue: "%DetectedFilePath%"
+    Values:
+      -
+        Name: DetectedFilePath
+        Value: "/Event/EventData/Data[@Name=\"DetectedFilePath\"]"
+
+# Documentation:
+# N/A
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="CiscoSecureEndpoint" Guid="0643104d-3c79-4ed5-9ed4-cd8e803fea9c" />
+#     <EventID>1310</EventID>
+#     <Version>1</Version>
+#     <Level>4</Level>
+#     <Task>10</Task>
+#     <Opcode>0</Opcode>
+#     <Keywords>0x8000000000000000</Keywords>
+#     <TimeCreated SystemTime="2022-03-05 19:12:53.1234567" />
+#     <EventRecordID>19</EventRecordID>
+#     <Correlation />
+#     <Execution ProcessID="1234" ThreadID="5678" />
+#     <Channel>CiscoSecureEndpoint/Events</Channel>
+#     <Computer>HOSTNAME.domain.com</Computer>
+#     <Security UserID="S-1-5-18" />
+#   </System>
+#  <EventData>
+#    <Data Name="DetectionId">7196742111364907012</Data>
+#    <Data Name="DetectedFilePath">C:\ProgramData\evil.exe</Data>
+#  </EventData>
+# </Event>


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [x] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [ ] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [x] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [x] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [x] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
