### PR TITLE
update nuget, add logic to solve https://github.com/EricZimmerman/evtx/issues/230

### DIFF
--- a/EvtxECmd/EvtxECmd.csproj
+++ b/EvtxECmd/EvtxECmd.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="ServiceStack.Text" Version="6.9.0" />
+    <PackageReference Include="ServiceStack.Text" Version="6.11.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
     
   </ItemGroup>

--- a/EvtxECmd/Program.cs
+++ b/EvtxECmd/Program.cs
@@ -543,30 +543,44 @@ namespace EvtxECmd;
             _includeIds = new HashSet<int>();
             _excludeIds = new HashSet<int>();
 
-            if (exc.IsNullOrEmpty() == false)
+            void HandleSegment(string segment, HashSet<int> idSet)
             {
-                var excSegs = exc.Split(',');
-
-                foreach (var incSeg in excSegs)
+                if (segment.Contains('-'))
                 {
-                    if (int.TryParse(incSeg, out var goodId))
+                    var rangeParts = segment.Split('-');
+                    if (int.TryParse(rangeParts[0], out var start) && int.TryParse(rangeParts[1], out var end))
                     {
-                        _excludeIds.Add(goodId);
+                        for (int i = start; i <= end; i++)
+                        {
+                            idSet.Add(i);
+                        }
+                    }
+                }
+                else
+                {
+                    if (int.TryParse(segment, out var goodId))
+                    {
+                        idSet.Add(goodId);
                     }
                 }
             }
 
-            if (inc.IsNullOrEmpty() == false)
+            if (!string.IsNullOrEmpty(exc))
+            {
+                var excSegs = exc.Split(',');
+                foreach (var excSeg in excSegs)
+                {
+                    HandleSegment(excSeg, _excludeIds);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(inc))
             {
                 _excludeIds.Clear();
                 var incSegs = inc.Split(',');
-
                 foreach (var incSeg in incSegs)
                 {
-                    if (int.TryParse(incSeg, out var goodId))
-                    {
-                        _includeIds.Add(goodId);
-                    }
+                    HandleSegment(incSeg, _includeIds);
                 }
             }
 

--- a/EvtxECmd/Program.cs
+++ b/EvtxECmd/Program.cs
@@ -550,7 +550,10 @@ namespace EvtxECmd;
                     var rangeParts = segment.Split('-');
                     if (int.TryParse(rangeParts[0], out var start) && int.TryParse(rangeParts[1], out var end))
                     {
-                        for (int i = start; i <= end; i++)
+                        int lowerBound = Math.Min(start, end);
+                        int upperBound = Math.Max(start, end);
+            
+                        for (int i = lowerBound; i <= upperBound; i++)
                         {
                             idSet.Add(i);
                         }

--- a/evtx/evtx.csproj
+++ b/evtx/evtx.csproj
@@ -23,11 +23,11 @@
   </PropertyGroup>
     <ItemGroup>
     <PackageReference Include="Crc32.NET" Version="1.2.0" />
-    <PackageReference Include="FluentValidation" Version="11.6.0" />
+    <PackageReference Include="FluentValidation" Version="11.7.1" />
       <PackageReference Include="Serilog" Version="3.0.1" />
-    <PackageReference Include="ServiceStack.Text" Version="6.9.0" />
+    <PackageReference Include="ServiceStack.Text" Version="6.11.0" />
     <PackageReference Include="System.Xml.XPath" Version="4.3.0" />
-    <PackageReference Include="YamlDotNet" Version="13.1.1" />
+    <PackageReference Include="YamlDotNet" Version="13.7.0" />
       <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
 
       <None Include="../README.md" Pack="true" PackagePath=""/>


### PR DESCRIPTION
## Description

update nuget packages

adds logic to resolve https://github.com/EricZimmerman/evtx/issues/230

This seemed like an easy one for ChatGPT to handle. @EricZimmerman feel free to modify as you see fit, of course, but I tested it and it works.

I also added logic to handle where if someone tries to pass `4700-4600` so it'll handle 4600 as the start, 4700 as the end, and iterate accordingly.

So tests with both `--inc` and `--exc` have passed using both `4600-4700` and `4700-4600`.

![image](https://github.com/EricZimmerman/evtx/assets/36825567/c976df7a-192d-452a-88e4-266517f60797)
