### PR TITLE
avoid CS0104 error on linux, make namespaces unabiguous

### DIFF
--- a/EvtxECmd/Program.cs
+++ b/EvtxECmd/Program.cs
@@ -555,14 +555,14 @@ namespace EvtxECmd;
             else
             {
                 Log.Debug("Loading maps from {Path}",Path.GetFullPath(maps));
-                var errors = EventLog.LoadMaps(Path.GetFullPath(maps));
+                var errors = evtx.EventLog.LoadMaps(Path.GetFullPath(maps));
 
                 if (errors)
                 {
                     return;
                 }
 
-                Log.Information("Maps loaded: {Count:N0}",EventLog.EventLogMaps.Count);
+                Log.Information("Maps loaded: {Count:N0}",evtx.EventLog.EventLogMaps.Count);
             }
 
             _includeIds = new HashSet<int>();
@@ -634,7 +634,7 @@ namespace EvtxECmd;
                 Console.WriteLine();
             }
 
-            EventLog.TimeDiscrepancyThreshold = tdt;
+            evtx.EventLog.TimeDiscrepancyThreshold = tdt;
 
             if (f.IsNullOrEmpty() == false)
             {
@@ -649,7 +649,7 @@ namespace EvtxECmd;
                 {
                     //no need for maps
                     Log.Debug("Clearing map collection since no output specified");
-                    EventLog.EventLogMaps.Clear();
+                    evtx.EventLog.EventLogMaps.Clear();
                 }
 
                 dedupe = false;
@@ -719,7 +719,7 @@ namespace EvtxECmd;
                 {
                     //no need for maps
                     Log.Debug("Clearing map collection since no output specified");
-                    EventLog.EventLogMaps.Clear();
+                    evtx.EventLog.EventLogMaps.Clear();
                 }
 
                 foreach (var file in files2)
@@ -1035,8 +1035,8 @@ namespace EvtxECmd;
                     SeenHashes.Add(sha);
                 }
 
-                EventLog.LastSeenTicks = 0;
-                var evt = new EventLog(fileS);
+                evtx.EventLog.LastSeenTicks = 0;
+                var evt = new evtx.EventLog(fileS);
 
                 Log.Information("Chunk count: {ChunkCount:N0}, Iterating records...",evt.ChunkCount);
 


### PR DESCRIPTION
## Description

When EvtxECmd is cloned to linux and build with net6 you get the following errors:
```
/home/flow/sources/evtx/EvtxECmd/Program.cs(558,30): error CS0104: "EventLog" ist ein mehrdeutiger Verweis zwischen "System.Diagnostics.EventLog" und "evtx.EventLog". [/home/flow/sources/evtx/EvtxECmd/EvtxECmd.csproj]
/home/flow/sources/evtx/EvtxECmd/Program.cs(565,59): error CS0104: "EventLog" ist ein mehrdeutiger Verweis zwischen "System.Diagnostics.EventLog" und "evtx.EventLog". [/home/flow/sources/evtx/EvtxECmd/EvtxECmd.csproj]
/home/flow/sources/evtx/EvtxECmd/Program.cs(637,13): error CS0104: "EventLog" ist ein mehrdeutiger Verweis zwischen "System.Diagnostics.EventLog" und "evtx.EventLog". [/home/flow/sources/evtx/EvtxECmd/EvtxECmd.csproj]
/home/flow/sources/evtx/EvtxECmd/Program.cs(652,21): error CS0104: "EventLog" ist ein mehrdeutiger Verweis zwischen "System.Diagnostics.EventLog" und "evtx.EventLog". [/home/flow/sources/evtx/EvtxECmd/EvtxECmd.csproj]
/home/flow/sources/evtx/EvtxECmd/Program.cs(722,21): error CS0104: "EventLog" ist ein mehrdeutiger Verweis zwischen "System.Diagnostics.EventLog" und "evtx.EventLog". [/home/flow/sources/evtx/EvtxECmd/EvtxECmd.csproj]
/home/flow/sources/evtx/EvtxECmd/Program.cs(1038,17): error CS0104: "EventLog" ist ein mehrdeutiger Verweis zwischen "System.Diagnostics.EventLog" und "evtx.EventLog". [/home/flow/sources/evtx/EvtxECmd/EvtxECmd.csproj]
/home/flow/sources/evtx/EvtxECmd/Program.cs(1039,31): error CS0104: "EventLog" ist ein mehrdeutiger Verweis zwischen "System.Diagnostics.EventLog" und "evtx.EventLog". [/home/flow/sources/evtx/EvtxECmd/EvtxECmd.csproj]
```

I changed the listed places and made the namspace to be used unabigiuous, now it compiles on linux like charm.

## Checklist:

**Note: i have not touched any Maps**

Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [ ] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [ ] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [ ] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [ ] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [ ] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
