### PR TITLE
System Name Changed 6011 Map

### DIFF
--- a/evtx/Maps/System_EventLog_6011.map
+++ b/evtx/Maps/System_EventLog_6011.map
@@ -1,0 +1,47 @@
+Author: Reece394
+Description: System Name Changed
+EventId: 6011
+Channel: System
+Provider: EventLog
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "The NetBIOS name and DNS host name of this machine have been changed from %OriginalName% to %NewName%"
+    Values:
+      -
+        Name: OriginalName
+        Value: "/Event/EventData/Data"
+        Refine: "^(.*?)(?=,|$)"
+      -
+        Name: NewName
+        Value: "/Event/EventData/Data"
+        Refine: "(?<=, ).*"
+
+# Documentation:
+# http://eventopedia.cloudapp.net/EventDetails.aspx?id=a4c6ad3e-0b56-40ea-aa6d-c84adcf24897
+# https://community.spiceworks.com/t/finding-old-computer-name-from-dc/826502
+# https://learn.microsoft.com/en-us/answers/questions/1060679/recall-previous-device-names-on-endpoint-manager
+#
+# Example Event Data:
+#<Event>
+#  <System>
+#    <Provider Name="EventLog" />
+#    <EventID Qualifiers="32768">6011</EventID>
+#    <Version>0</Version>
+#    <Level>4</Level>
+#    <Task>0</Task>
+#    <Opcode>0</Opcode>
+#    <Keywords>0x80000000000000</Keywords>
+#    <TimeCreated SystemTime="2024-05-28 00:46:49.8687258" />
+#    <EventRecordID>148</EventRecordID>
+#    <Correlation />
+#    <Execution ProcessID="2592" ThreadID="2676" />
+#    <Channel>System</Channel>
+#    <Computer>DESKTOP-F3BMVE4</Computer>
+#    <Security />
+#  </System>
+#  <EventData>
+#    <Data>WIN-76PGSVBIM7I, DESKTOP-F3BMVE4</Data>
+#    <Binary></Binary>
+#  </EventData>
+#</Event>

--- a/evtx/Maps/System_EventLog_6011.map
+++ b/evtx/Maps/System_EventLog_6011.map
@@ -23,25 +23,25 @@ Maps:
 # https://learn.microsoft.com/en-us/answers/questions/1060679/recall-previous-device-names-on-endpoint-manager
 #
 # Example Event Data:
-#<Event>
-#  <System>
-#    <Provider Name="EventLog" />
-#    <EventID Qualifiers="32768">6011</EventID>
-#    <Version>0</Version>
-#    <Level>4</Level>
-#    <Task>0</Task>
-#    <Opcode>0</Opcode>
-#    <Keywords>0x80000000000000</Keywords>
-#    <TimeCreated SystemTime="2024-05-28 00:46:49.8687258" />
-#    <EventRecordID>148</EventRecordID>
-#    <Correlation />
-#    <Execution ProcessID="2592" ThreadID="2676" />
-#    <Channel>System</Channel>
-#    <Computer>DESKTOP-F3BMVE4</Computer>
-#    <Security />
-#  </System>
-#  <EventData>
-#    <Data>WIN-76PGSVBIM7I, DESKTOP-F3BMVE4</Data>
-#    <Binary></Binary>
-#  </EventData>
-#</Event>
+# <Event>
+#   <System>
+#     <Provider Name="EventLog" />
+#     <EventID Qualifiers="32768">6011</EventID>
+#     <Version>0</Version>
+#     <Level>4</Level>
+#     <Task>0</Task>
+#     <Opcode>0</Opcode>
+#     <Keywords>0x80000000000000</Keywords>
+#     <TimeCreated SystemTime="2024-05-28 00:46:49.8687258" />
+#     <EventRecordID>148</EventRecordID>
+#     <Correlation />
+#     <Execution ProcessID="2592" ThreadID="2676" />
+#     <Channel>System</Channel>
+#     <Computer>DESKTOP-F3BMVE4</Computer>
+#     <Security />
+#   </System>
+#   <EventData>
+#     <Data>WIN-76PGSVBIM7I, DESKTOP-F3BMVE4</Data>
+#     <Binary></Binary>
+#   </EventData>
+# </Event>


### PR DESCRIPTION
## Description

Added a map file for Event ID 6011 which is triggered when the system name is changed. 

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [X] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [X] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [X] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
