### PR TITLE
Antivirus Maps

### DIFF
--- a/evtx/Maps/Application_FSecure-FSecure-Application-F-Secure-Anti-Virus_103.map
+++ b/evtx/Maps/Application_FSecure-FSecure-Application-F-Secure-Anti-Virus_103.map
@@ -1,0 +1,56 @@
+Author: Reece394
+Description: F-Secure Anti-Virus - Manual scanning was finished - workstation was found infected
+EventId: 103
+Channel: "Application"
+Provider: "FSecure-FSecure Application-F-Secure Anti-Virus"
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "%PayloadData1%"
+    Values:
+      -
+        Name: PayloadData1
+        Value: "/Event/EventData/Data[@Name=\"MessageText\"]"
+  -
+    Property: PayloadData2
+    PropertyValue: "%PayloadData2%"
+    Values:
+      -
+        Name: PayloadData2
+        Value: "/Event/EventData/Data[@Name=\"UserName\"]"
+
+# Documentation:
+# N/A
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="FSecure-FSecure Application-F-Secure Anti-Virus" Guid="14226663-5b17-4fcc-b09b-4d2644e4a1e7" />
+#     <EventID>103</EventID>
+#     <Version>0</Version>
+#     <Level>1</Level>
+#     <Task>0</Task>
+#     <Opcode>0</Opcode>
+#     <Keywords>0x8000000000000000</Keywords>
+#     <TimeCreated SystemTime="2024-01-06 20:50:27.6710933" />
+#     <EventRecordID>706</EventRecordID>
+#     <Correlation />
+#     <Execution ProcessID="3096" ThreadID="2272" />
+#     <Channel>Application</Channel>
+#     <Computer>User-PC</Computer>
+#     <Security UserID="S-1-5-18" />
+#   </System>
+#   <EventData>
+#     <Data Name="MessageText">Manual scanning was finished - workstation was found infected!</Data>
+#     <Data Name="TrapTimestamp">1704574227</Data>
+#     <Data Name="TrapId">103</Data>
+#     <Data Name="TrapNumber">9</Data>
+#     <Data Name="Severity">5</Data>
+#     <Data Name="HostName">user-pc</Data>
+#     <Data Name="UserName">User-PC\User</Data>
+#     <Data Name="ProductOID">1.3.6.1.4.1.2213.12</Data>
+#     <Data Name="ProductName">F-Secure Anti-Virus</Data>
+#     <Data Name="ParamCount">0</Data>
+#     <Data Name="Param"></Data>
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Application_FSecure-FSecure-Application-F-Secure-Anti-Virus_207.map
+++ b/evtx/Maps/Application_FSecure-FSecure-Application-F-Secure-Anti-Virus_207.map
@@ -1,0 +1,56 @@
+Author: Reece394
+Description: F-Secure Anti-Virus - Malicious code found in file
+EventId: 207
+Channel: "Application"
+Provider: "FSecure-FSecure Application-F-Secure Anti-Virus"
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "%PayloadData1%"
+    Values:
+      -
+        Name: PayloadData1
+        Value: "/Event/EventData/Data[@Name=\"MessageText\"]"
+  -
+    Property: PayloadData2
+    PropertyValue: "%PayloadData2%"
+    Values:
+      -
+        Name: PayloadData2
+        Value: "/Event/EventData/Data[@Name=\"UserName\"]"
+
+# Documentation:
+# N/A
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="FSecure-FSecure Application-F-Secure Anti-Virus" Guid="14226663-5b17-4fcc-b09b-4d2644e4a1e7" />
+#     <EventID>207</EventID>
+#     <Version>0</Version>
+#     <Level>1</Level>
+#     <Task>0</Task>
+#     <Opcode>0</Opcode>
+#     <Keywords>0x8000000000000000</Keywords>
+#     <TimeCreated SystemTime="2024-01-06 20:23:11.2496022" />
+#     <EventRecordID>703</EventRecordID>
+#     <Correlation />
+#     <Execution ProcessID="3096" ThreadID="2272" />
+#     <Channel>Application</Channel>
+#     <Computer>User-PC</Computer>
+#     <Security UserID="S-1-5-18" />
+#   </System>
+#   <EventData>
+#     <Data Name="MessageText">Malicious code found in file C:\Users\User\Downloads\mimikatz_trunk\x64\mimispool.dll. , Infection: Heuristic.HEUR/AGEN.1240390 , Action: The file was quarantined. , </Data>
+#     <Data Name="TrapTimestamp">1704572591</Data>
+#     <Data Name="TrapId">207</Data>
+#     <Data Name="TrapNumber">8</Data>
+#     <Data Name="Severity">5</Data>
+#     <Data Name="HostName">user-pc</Data>
+#     <Data Name="UserName">User-PC\User</Data>
+#     <Data Name="ProductOID">1.3.6.1.4.1.2213.12</Data>
+#     <Data Name="ProductName">F-Secure Anti-Virus</Data>
+#     <Data Name="ParamCount">3</Data>
+#     <Data Name="Param">C:\Users\User\Downloads\mimikatz_trunk\x64\mimispool.dll, Heuristic.HEUR/AGEN.1240390</Data>
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Application_FSecure-FSecure-Application-F-Secure-Anti-Virus_296.map
+++ b/evtx/Maps/Application_FSecure-FSecure-Application-F-Secure-Anti-Virus_296.map
@@ -1,0 +1,56 @@
+Author: Reece394
+Description: F-Secure Anti-Virus - Spyware detected
+EventId: 296
+Channel: "Application"
+Provider: "FSecure-FSecure Application-F-Secure Anti-Virus"
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "%PayloadData1%"
+    Values:
+      -
+        Name: PayloadData1
+        Value: "/Event/EventData/Data[@Name=\"MessageText\"]"
+  -
+    Property: PayloadData2
+    PropertyValue: "%PayloadData2%"
+    Values:
+      -
+        Name: PayloadData2
+        Value: "/Event/EventData/Data[@Name=\"UserName\"]"
+
+# Documentation:
+# N/A
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="FSecure-FSecure Application-F-Secure Anti-Virus" Guid="14226663-5b17-4fcc-b09b-4d2644e4a1e7" />
+#     <EventID>296</EventID>
+#     <Version>0</Version>
+#     <Level>1</Level>
+#     <Task>0</Task>
+#     <Opcode>0</Opcode>
+#     <Keywords>0x8000000000000000</Keywords>
+#     <TimeCreated SystemTime="2024-01-06 20:23:11.0000017" />
+#     <EventRecordID>698</EventRecordID>
+#     <Correlation />
+#     <Execution ProcessID="3096" ThreadID="2272" />
+#     <Channel>Application</Channel>
+#     <Computer>User-PC</Computer>
+#     <Security UserID="S-1-5-18" />
+#   </System>
+#   <EventData>
+#     <Data Name="MessageText">Spyware detected: , Type: riskware , Family:  , Name: Hack-Tool:W32/Mimikatz.G , Object: C:\Users\User\Downloads\mimikatz_trunk\Win32\mimidrv.sys , </Data>
+#     <Data Name="TrapTimestamp">1704572591</Data>
+#     <Data Name="TrapId">296</Data>
+#     <Data Name="TrapNumber">3</Data>
+#     <Data Name="Severity">5</Data>
+#     <Data Name="HostName">user-pc</Data>
+#     <Data Name="UserName">User-PC\User</Data>
+#     <Data Name="ProductOID">1.3.6.1.4.1.2213.12</Data>
+#     <Data Name="ProductName">F-Secure Anti-Virus</Data>
+#     <Data Name="ParamCount">4</Data>
+#     <Data Name="Param">riskware, Hack-Tool:W32/Mimikatz.G, C:\Users\User\Downloads\mimikatz_trunk\Win32\mimidrv.sys</Data>
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Application_FSecure-FSecure-Application-F-Secure-Anti-Virus_722.map
+++ b/evtx/Maps/Application_FSecure-FSecure-Application-F-Secure-Anti-Virus_722.map
@@ -1,0 +1,56 @@
+Author: Reece394
+Description: F-Secure Anti-Virus - Web Traffic Scanning Alert
+EventId: 722
+Channel: "Application"
+Provider: "FSecure-FSecure Application-F-Secure Anti-Virus"
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "%PayloadData1%"
+    Values:
+      -
+        Name: PayloadData1
+        Value: "/Event/EventData/Data[@Name=\"MessageText\"]"
+  -
+    Property: PayloadData2
+    PropertyValue: "%PayloadData2%"
+    Values:
+      -
+        Name: PayloadData2
+        Value: "/Event/EventData/Data[@Name=\"UserName\"]"
+
+# Documentation:
+# N/A
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="FSecure-FSecure Application-F-Secure Anti-Virus" Guid="14226663-5b17-4fcc-b09b-4d2644e4a1e7" />
+#     <EventID>722</EventID>
+#     <Version>0</Version>
+#     <Level>1</Level>
+#     <Task>0</Task>
+#     <Opcode>0</Opcode>
+#     <Keywords>0x8000000000000000</Keywords>
+#     <TimeCreated SystemTime="2024-01-06 20:18:01.2138813" />
+#     <EventRecordID>696</EventRecordID>
+#     <Correlation />
+#     <Execution ProcessID="3096" ThreadID="2272" />
+#     <Channel>Application</Channel>
+#     <Computer>User-PC</Computer>
+#     <Security UserID="S-1-5-18" />
+#   </System>
+#   <EventData>
+#     <Data Name="MessageText">Web Traffic Scanning Alert , Infection: http://malware.wicar.org/data/eicar.com , Object name: EICAR_Test_File , Action: Malicious content was blocked.</Data>
+#     <Data Name="TrapTimestamp">1704572281</Data>
+#     <Data Name="TrapId">722</Data>
+#     <Data Name="TrapNumber">1</Data>
+#     <Data Name="Severity">5</Data>
+#     <Data Name="HostName">user-pc</Data>
+#     <Data Name="UserName">User-PC\User</Data>
+#     <Data Name="ProductOID">1.3.6.1.4.1.2213.12</Data>
+#     <Data Name="ProductName">F-Secure Anti-Virus</Data>
+#     <Data Name="ParamCount">3</Data>
+#     <Data Name="Param">http://malware.wicar.org/data/eicar.com, EICAR_Test_File</Data>
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Application_FSecure-FSecure-F-Secure-Anti-Virus_103.map
+++ b/evtx/Maps/Application_FSecure-FSecure-F-Secure-Anti-Virus_103.map
@@ -43,7 +43,7 @@ Maps:
 #  Malicious code found in file C:\Users\User\Downloads\mimikatz_trunk\Win32\mimilove.exe. 
 #  Infection: Heuristic.HEUR/AGEN.1221331 
 #  Action: The file was deleted. 
-# 
+#
 # </Data>
 #     <Binary></Binary>
 #   </EventData>

--- a/evtx/Maps/Application_FSecure-FSecure-F-Secure-Anti-Virus_103.map
+++ b/evtx/Maps/Application_FSecure-FSecure-F-Secure-Anti-Virus_103.map
@@ -40,9 +40,9 @@ Maps:
 #   </System>
 #   <EventData>
 #     <Data>2  2024-01-06  18:57:21+00:00  user-pc  User-PC\User  F-Secure Anti-Virus
-#  Malicious code found in file C:\Users\User\Downloads\mimikatz_trunk\Win32\mimilove.exe. 
-#  Infection: Heuristic.HEUR/AGEN.1221331 
-#  Action: The file was deleted. 
+#  Malicious code found in file C:\Users\User\Downloads\mimikatz_trunk\Win32\mimilove.exe.
+#  Infection: Heuristic.HEUR/AGEN.1221331
+#  Action: The file was deleted.
 #
 # </Data>
 #     <Binary></Binary>

--- a/evtx/Maps/Application_FSecure-FSecure-F-Secure-Anti-Virus_103.map
+++ b/evtx/Maps/Application_FSecure-FSecure-F-Secure-Anti-Virus_103.map
@@ -1,0 +1,50 @@
+Author: Reece394
+Description: F-Secure Anti-Virus Detection
+EventId: 103
+Channel: "Application"
+Provider: "FSecure-FSecure-F-Secure Anti-Virus"
+Maps:
+  -
+    Property: UserName
+    PropertyValue: "%UserName%"
+    Values:
+      -
+        Name: UserName
+        Value: "/Event/EventData/Data"
+        Refine: "(?<=^([^  ]*  ){4})[^  ]+"
+  -
+    Property: PayloadData1
+    PropertyValue: "%PayloadData1%"
+    Values:
+      -
+        Name: PayloadData1
+        Value: "/Event/EventData/Data"
+        Refine: "(?<=\n )(.*)"
+
+# Documentation:
+# N/A
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="FSecure-FSecure-F-Secure Anti-Virus" />
+#     <EventID Qualifiers="49152">103</EventID>
+#     <Level>2</Level>
+#     <Task>0</Task>
+#     <Keywords>0x80000000000000</Keywords>
+#     <TimeCreated SystemTime="2024-01-06 18:57:22.0000000" />
+#     <EventRecordID>732</EventRecordID>
+#     <Channel>Application</Channel>
+#     <Computer>User-PC</Computer>
+#     <Security />
+#   </System>
+#   <EventData>
+#     <Data>2  2024-01-06  18:57:21+00:00  user-pc  User-PC\User  F-Secure Anti-Virus
+#  Malicious code found in file C:\Users\User\Downloads\mimikatz_trunk\Win32\mimilove.exe. 
+#  Infection: Heuristic.HEUR/AGEN.1221331 
+#  Action: The file was deleted. 
+# 
+# </Data>
+#     <Binary></Binary>
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Application_Trellix-Endpoint-Security_3.map
+++ b/evtx/Maps/Application_Trellix-Endpoint-Security_3.map
@@ -1,0 +1,51 @@
+Author: Peter Snyder, Reece394
+Description: Trellix Endpoint Detection
+EventId: 3
+Channel: "Application"
+Provider: "Trellix Endpoint Security"
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "%PayloadData1%"
+    Values:
+      -
+        Name: PayloadData1
+        Value: "/Event/EventData/Data"
+        Refine: EventID=(\d{1,4})\b
+  -
+    Property: PayloadData2
+    PropertyValue: "%PayloadData2%"
+    Values:
+      -
+        Name: PayloadData2
+        Value: "/Event/EventData/Data"
+        Refine: (\S+ (ran|file).*(Trojan|detected|blocked|executed).*.)
+
+# Documentation:
+# N/A
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="Trellix Endpoint Security" />
+#     <EventID Qualifiers="8192">3</EventID>
+#     <Version>0</Version>
+#     <Level>2</Level>
+#     <Task>0</Task>
+#     <Opcode>0</Opcode>
+#     <Keywords>0x80000000000000</Keywords>
+#     <TimeCreated SystemTime="2024-01-03 23:29:00.6240345" />
+#     <EventRecordID>811</EventRecordID>
+#     <Correlation />
+#     <Execution ProcessID="3584" ThreadID="0" />
+#     <Channel>Application</Channel>
+#     <Computer>DESKTOP-8EB4LCL</Computer>
+#     <Security UserID="S-1-5-18" />
+#   </System>
+#   <EventData>
+#     <Data>EventID=1027
+# 
+# DESKTOP-8EB4LCL\User ran C:\Program Files\7-Zip\7zG.exe, which attempted to access C:\Users\User\Downloads\1a69f2fcfe5b35bf44ea42a1efe89f18f6b0d522cbbea5c51bae93aff7d3188b\1a69f2fcfe5b35bf44ea42a1efe89f18f6b0d522cbbea5c51bae93aff7d3188b.exe. The Trojan named Artemis!5FE4EA367CEE was detected and deleted.</Data>
+#     <Binary></Binary>
+#   </EventData>
+# </Event>

--- a/evtx/Maps/Application_Trellix-Endpoint-Security_3.map
+++ b/evtx/Maps/Application_Trellix-Endpoint-Security_3.map
@@ -44,7 +44,7 @@ Maps:
 #   </System>
 #   <EventData>
 #     <Data>EventID=1027
-# 
+#
 # DESKTOP-8EB4LCL\User ran C:\Program Files\7-Zip\7zG.exe, which attempted to access C:\Users\User\Downloads\1a69f2fcfe5b35bf44ea42a1efe89f18f6b0d522cbbea5c51bae93aff7d3188b\1a69f2fcfe5b35bf44ea42a1efe89f18f6b0d522cbbea5c51bae93aff7d3188b.exe. The Trojan named Artemis!5FE4EA367CEE was detected and deleted.</Data>
 #     <Binary></Binary>
 #   </EventData>


### PR DESCRIPTION
## Description

Added Trellix Endpoint Security Map based on the work from Peter Snyder on McAfee Endpoint Security (Worked without changes beyond the Provider Name)
Added F-Secure Anti-Virus 12 Security Maps (May work on other versions but 12 was the only one tested for these rules)
Added F-Secure Anti-Virus 11 Security Map (May work on other versions but 11 was the only one tested for these rules)

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [X] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [X] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [X] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
