### PR TITLE
Windows Security Center State Changed Map

### DIFF
--- a/evtx/Maps/Application_SecurityCenter_15.map
+++ b/evtx/Maps/Application_SecurityCenter_15.map
@@ -1,0 +1,45 @@
+Author: Reece394
+Description: Windows Security Center State Changed
+EventId: 15
+Channel: Application
+Provider: SecurityCenter
+Maps:
+  -
+    Property: PayloadData1
+    PropertyValue: "Updated %Name% status successfully to %State%."
+    Values:
+      -
+        Name: Name
+        Value: "/Event/EventData/Data"
+        Refine: "^(.*?)(?=,)"
+      -
+        Name: State
+        Value: "/Event/EventData/Data"
+        Refine: "(?<=, ).*"
+
+# Documentation:
+# https://isc.sans.edu/diary/rss/30980
+#
+# Example Event Data:
+# <Event>
+#   <System>
+#     <Provider Name="SecurityCenter" />
+#     <EventID Qualifiers="0">15</EventID>
+#     <Version>0</Version>
+#     <Level>4</Level>
+#     <Task>0</Task>
+#     <Opcode>0</Opcode>
+#     <Keywords>0x80000000000000</Keywords>
+#     <TimeCreated SystemTime="2024-06-01 01:50:28.8518116" />
+#     <EventRecordID>418</EventRecordID>
+#     <Correlation />
+#     <Execution ProcessID="1160" ThreadID="0" />
+#     <Channel>Application</Channel>
+#     <Computer>DESKTOP-F3BMVE4</Computer>
+#     <Security />
+#   </System>
+#   <EventData>
+#     <Data>Windows Defender, SECURITY_PRODUCT_STATE_ON</Data>
+#     <Binary></Binary>
+#   </EventData>
+# </Event>


### PR DESCRIPTION
## Description
I read an interesting post on SANS [here](https://isc.sans.edu/diary/rss/30980) and noticed the Event Log mentioned wasn't mapped yet hence the pull request.

Added a map file for Event ID 15 which is triggered when the Security Center state is changed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [X] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [X] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [X] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
