### PR TITLE
Update Microsoft-Windows-Dhcp-Client-Admin_Microsoft-Windows-Dhcp-Cli…

### DIFF
--- a/evtx/Maps/Microsoft-Windows-Dhcp-Client-Admin_Microsoft-Windows-Dhcp-Client_50067.map
+++ b/evtx/Maps/Microsoft-Windows-Dhcp-Client-Admin_Microsoft-Windows-Dhcp-Client_50067.map
@@ -10,7 +10,7 @@ Maps:
     Values:
       -
         Name: PayloadData1
-        Value: "/Event/EventData/Data[@Name=\"NetworkHint\"]"
+        Value: "/Event/EventData/Data[@Name=\"NetworkHintString\"]"
         Refine: "(?<=, )[^,\\d]+(?=,)"
   -
     Property: PayloadData2
@@ -42,8 +42,8 @@ Maps:
 #     <Security UserID="S-1-5-19" />
 #   </System>
 #   <EventData>
-#     <Data Name="NetworkHintString">WiFi_SSID</Data>
-#     <Data Name="NetworkHint">576946695F53534944</Data>
+#     <Data Name="NetworkHintString">WiFi_SSID_String</Data>
+#     <Data Name="NetworkHint">576946695F535349445F537472696E67</Data>
 #     <Data Name="HWLength">6</Data>
 #     <Data Name="HWAddress">001122334455</Data>
 #   </EventData>


### PR DESCRIPTION
…ent_50067.map

Updated to pull SSID string instead of hex (which may not always match)

## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]` OR click on the checkboxes after you submit your PR

- [X] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [X] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [X] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [X] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [X] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
