### PR TITLE
Remove ephemeral port from RemoteHost to simplify grouping by initiating system

### DIFF
--- a/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_5140.map
+++ b/evtx/Maps/Security_Microsoft-Windows-Security-Auditing_5140.map
@@ -16,14 +16,11 @@ Maps:
         Value: "/Event/EventData/Data[@Name=\"SubjectUserName\"]"
   -
     Property: RemoteHost
-    PropertyValue: "%IpAddress%:%port%"
+    PropertyValue: "%IpAddress%"
     Values:
       -
         Name: IpAddress
         Value: "/Event/EventData/Data[@Name=\"IpAddress\"]"
-      -
-        Name: port
-        Value: "/Event/EventData/Data[@Name=\"IpPort\"]"
   -
     Property: PayloadData1
     PropertyValue: "Share: %ShareName% (%ShareLocalPath%)"


### PR DESCRIPTION
## Description

Removed the port mapping to simplify the `RemoteHost` property in the existing Security 5140 map. Including ephemeral ports in `RemoteHost` prevents grouping by source IP. This change improves usability without affecting the correctness of the map.

No new map was added; this is a change to an existing map.

## Checklist:
_Not applicable — this PR modifies an existing map._

- [ ] I have ensured a `Provider` is listed for the new Map(s) being submitted
- [ ] I have ensured the filename(s) of any new Map(s) being submitted follows the approved format, i.e. `Channel-Name_Provider-Name_EventID.map`. In summary, all spaces and special characters are replaced with a hyphen with an underscore separates Channel Name, Provider Name, and Event ID
- [ ] I have tested and validated the new Map(s) work with my test data and achieve the desired output
- [ ] I have provided example event data (`# Example Event Data:`) at the bottom of my Map(s), if possible
- [ ] I have consulted the [Guide](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.guide)/[Template](https://github.com/EricZimmerman/evtx/blob/master/evtx/Maps/!Channel-Name_Provider-Name_EventID.template) to ensure my Map(s) follow the same format

Small cleanup to the 5140 map to make `RemoteHost` grouping by IP easier. Thanks for maintaining this repo!
