### PR TITLE
Enhance parser reliability and fix map keying issues

### DIFF
--- a/EvtxECmd/FodyWeavers.xsd
+++ b/EvtxECmd/FodyWeavers.xsd
@@ -27,6 +27,16 @@
                   <xs:documentation>A list of runtime assembly names to include from the default action of "embed all Copy Local references", delimited with line breaks.</xs:documentation>
                 </xs:annotation>
               </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="ExcludeRuntimes" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of runtimes to exclude from the default action of "embed all Copy Local references", delimited with line breaks</xs:documentation>
+                </xs:annotation>
+              </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="IncludeRuntimes" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>A list of runtimes names to include from the default action of "embed all Copy Local references", delimited with line breaks.</xs:documentation>
+                </xs:annotation>
+              </xs:element>
               <xs:element minOccurs="0" maxOccurs="1" name="Unmanaged32Assemblies" type="xs:string">
                 <xs:annotation>
                   <xs:documentation>Obsolete, use UnmanagedWinX86Assemblies instead</xs:documentation>

--- a/EvtxECmd/Program.cs
+++ b/EvtxECmd/Program.cs
@@ -1210,7 +1210,10 @@ namespace EvtxECmd;
                     catch (Exception e)
                     {
                         Log.Error("Error processing record #{RecordNumber}: {Message}",eventRecord.RecordNumber,e.Message);
-                        evt.ErrorRecords.Add(21, e.Message);
+                        if (evt.ErrorRecords.ContainsKey(eventRecord.RecordNumber) == false)
+                        {
+                            evt.ErrorRecords.Add(eventRecord.RecordNumber, e.Message);
+                        }
                     }
                 }
 

--- a/EvtxECmd/Program.cs
+++ b/EvtxECmd/Program.cs
@@ -1173,11 +1173,13 @@ namespace EvtxECmd;
 
                     try
                     {
-                        var xdo = new XmlDocument();
-                        xdo.LoadXml(eventRecord.Payload);
-
-                        var payOut = JsonConvert.SerializeXmlNode(xdo);
-                        eventRecord.Payload = payOut;
+                        if (_csvWriter != null || _swJson != null)
+                        {
+                            if (TryGetPayloadAsJson(eventRecord.Payload, out var payOut))
+                            {
+                                eventRecord.Payload = payOut;
+                            }
+                        }
 
                         _csvWriter?.WriteRecord(eventRecord);
                         _csvWriter?.NextRecord();
@@ -1302,6 +1304,22 @@ namespace EvtxECmd;
             var xdo = new XmlDocument();
             xdo.LoadXml(xmlPayload);
             return JsonConvert.SerializeXmlNode(xdo);
+        }
+
+        private static bool TryGetPayloadAsJson(string xmlPayload, out string payloadAsJson)
+        {
+            payloadAsJson = xmlPayload;
+
+            try
+            {
+                payloadAsJson = GetPayloadAsJson(xmlPayload);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning("Unable to convert payload to JSON. Keeping original payload. Error: {Message}",ex.Message);
+                return false;
+            }
         }
 
         private static bool IsAdministrator()

--- a/EvtxECmd/Program.cs
+++ b/EvtxECmd/Program.cs
@@ -611,6 +611,7 @@ namespace EvtxECmd;
                 foo.Map(t => t.SourceFile).Index(22);
                 foo.Map(t => t.Keywords).Index(23);
                 foo.Map(t => t.Payload).Index(24);
+                foo.Map(t => t.RenderingInfo).Index(25);
 
                 _csvWriter.Context.RegisterClassMap(foo);
                 _csvWriter.WriteHeader<EventRecord>();

--- a/evtx/ChunkInfo.cs
+++ b/evtx/ChunkInfo.cs
@@ -169,6 +169,12 @@ public class ChunkInfo
 
         while (index < chunkBytes.Length)
         {
+            if (index + 8 > chunkBytes.Length)
+            {
+                Log.Verbose("Not enough bytes left in chunk for a record header. Stopping");
+                break;
+            }
+
             var sig = BitConverter.ToInt32(chunkBytes, index);
 
             if (sig != recordSig)
@@ -181,7 +187,7 @@ public class ChunkInfo
             var recordOffset = index;
 
             //do not read past the last known defined record
-            if (recordOffset - absoluteOffset > LastRecordOffset)
+            if (recordOffset > LastRecordOffset)
             {
                 Log.Verbose(
                     "Reached last record offset. Stopping");
@@ -189,6 +195,24 @@ public class ChunkInfo
             }
 
             var recordSize = BitConverter.ToUInt32(chunkBytes, index + 4);
+
+            if (recordSize < 0x18)
+            {
+                Log.Verbose("Invalid record size {RecordSize} at 0x{Offset:X}. Stopping",recordSize,AbsoluteOffset + recordOffset);
+                break;
+            }
+
+            if ((long) index + recordSize > chunkBytes.Length)
+            {
+                Log.Verbose("Record size {RecordSize} at 0x{Offset:X} exceeds remaining chunk bytes. Stopping",recordSize,AbsoluteOffset + recordOffset);
+                break;
+            }
+
+            if ((long) recordOffset + recordSize > FreeSpaceOffset)
+            {
+                Log.Verbose("Record at 0x{Offset:X} extends beyond free space offset. Stopping",AbsoluteOffset + recordOffset);
+                break;
+            }
 
             var recordNumber = BitConverter.ToInt64(chunkBytes, index + 8);
 

--- a/evtx/ChunkInfo.cs
+++ b/evtx/ChunkInfo.cs
@@ -202,13 +202,15 @@ public class ChunkInfo
                 break;
             }
 
-            if ((long) index + recordSize > chunkBytes.Length)
+            var recordEndOffset = recordOffset + recordSize;
+
+            if (recordEndOffset > chunkBytes.Length)
             {
                 Log.Verbose("Record size {RecordSize} at 0x{Offset:X} exceeds remaining chunk bytes. Stopping",recordSize,AbsoluteOffset + recordOffset);
                 break;
             }
 
-            if ((long) recordOffset + recordSize > FreeSpaceOffset)
+            if (recordEndOffset > FreeSpaceOffset)
             {
                 Log.Verbose("Record at 0x{Offset:X} extends beyond free space offset. Stopping",AbsoluteOffset + recordOffset);
                 break;

--- a/evtx/EventLog.cs
+++ b/evtx/EventLog.cs
@@ -130,21 +130,13 @@ public class EventLog
 
                 if (DisplayValidationResults(validate, mapFile))
                 {
-                    if (EventLogMaps.ContainsKey(
-                            $"{eventMapFile.EventId}-{eventMapFile.Channel.ToUpperInvariant()}") == false)
+                    var mapKey =
+                        $"{eventMapFile.EventId}-{eventMapFile.Channel.ToUpperInvariant()}-{eventMapFile.Provider.ToUpperInvariant()}";
+
+                    if (EventLogMaps.ContainsKey(mapKey) == false)
                     {
                         Log.Debug("{Path} is valid. Adding to maps...",Path.GetFileName(mapFile));
-
-                        // if (eventMapFile.Provider.IsNullOrEmpty() == false)
-                        // {
-                        //     EventLogMaps.Add($"{eventMapFile.EventId}-{eventMapFile.Channel.ToUpperInvariant()}-{eventMapFile.Provider.ToUpperInvariant()}", eventMapFile);
-                        // }
-                        // else
-                        // {
-                        //     
-                        // }
-                        EventLogMaps.Add($"{eventMapFile.EventId}-{eventMapFile.Channel.ToUpperInvariant()}-{eventMapFile.Provider.ToUpperInvariant()}", eventMapFile);    
-                            
+                        EventLogMaps.Add(mapKey, eventMapFile);    
                     }
                     else
                     {

--- a/evtx/EventRecord.cs
+++ b/evtx/EventRecord.cs
@@ -15,6 +15,9 @@ namespace evtx;
 
 public class EventRecord
 {
+    private static readonly Regex UnescapedAmpersandRegex =
+        new("&(?!amp;|lt;|gt;|quot;|apos;|#\\d+;|#x[0-9A-Fa-f]+;)", RegexOptions.Compiled);
+
     public EventRecord(BinaryReader recordData, int recordPosition, ChunkInfo chunk)
     {
         RecordPosition = recordPosition;
@@ -54,20 +57,19 @@ public class EventRecord
 
                 var found2a = true; //danderspritz test
                 var maxCount = 0;
-                while (maxCount < 15)
+                while (maxCount < 15 && recordData.BaseStream.Position < recordData.BaseStream.Length)
                 {
-                    if (recordData.BaseStream.Position == recordData.BaseStream.Length)
-                    {
-                        found2a = false;
-                        break; //out of data
-                    }
-
                     if (recordData.ReadByte() == 0x2a)
                     {
                         break;
                     }
                     
                     maxCount += 1;
+                }
+
+                if (recordData.BaseStream.Position >= recordData.BaseStream.Length)
+                {
+                    found2a = false;
                 }
                     
                 if (found2a)
@@ -452,7 +454,7 @@ public class EventRecord
         }
         catch (XmlException)
         {
-            rawXml = Regex.Replace(rawXml, "&(?!amp;|lt;|gt;|quot;|apos;|#\\d+;|#x[0-9A-Fa-f]+;)", "&amp;");
+            rawXml = UnescapedAmpersandRegex.Replace(rawXml, "&amp;");
             xmld.LoadXml(rawXml);
         }
 

--- a/evtx/EventRecord.cs
+++ b/evtx/EventRecord.cs
@@ -151,142 +151,160 @@ public class EventRecord
         {
             if (reader.IsStartElement())
             {
-                switch (reader.Name)
+                try
                 {
-                    case "Computer":
-                        reader.Read();
-                        Computer = reader.Value;
-                        break;
-                    case "Channel":
-                        reader.Read();
-                        Channel = reader.Value;
-                        break;
-                    case "EventRecordID":
-                        EventRecordId = reader.ReadElementContentAsString();
-                        break;
-                    case "EventID":
-                        EventId = reader.ReadElementContentAsInt();
-                        break;
-                    case "Level":
-                        var lvl = reader.ReadElementContentAsInt();
-                            
-                        switch (lvl)
-                        {
-                            case 0:
-                                Level = "LogAlways";
-                                break;
-                            case 1:
-                                Level = "Critical";
-                                break;
-                            case 2:
-                                Level = "Error";
-                                break;
-                            case 3:
-                                Level = "Warning";
-                                break;
-                            case 4:
-                                Level = "Info";
-                                break;
-                            case 5:
-                                Level = "Verbose";
-                                break;
-                            
-                            case 8:
-                                Level = "Success";
-                                break;
-                            case 16:
-                                Level = "Failure";
-                                break;
-                            default:
-                                Level = lvl.ToString();
-                                break;
-                        }
+                    switch (reader.Name)
+                    {
+                        case "Computer":
+                            reader.Read();
+                            Computer = reader.Value;
+                            break;
+                        case "Channel":
+                            reader.Read();
+                            Channel = reader.Value;
+                            break;
+                        case "EventRecordID":
+                            EventRecordId = reader.ReadElementContentAsString();
+                            break;
+                        case "EventID":
+                            EventId = reader.ReadElementContentAsInt();
+                            break;
+                        case "Level":
+                            var lvl = reader.ReadElementContentAsInt();
 
-                        break;
+                            switch (lvl)
+                            {
+                                case 0:
+                                    Level = "LogAlways";
+                                    break;
+                                case 1:
+                                    Level = "Critical";
+                                    break;
+                                case 2:
+                                    Level = "Error";
+                                    break;
+                                case 3:
+                                    Level = "Warning";
+                                    break;
+                                case 4:
+                                    Level = "Info";
+                                    break;
+                                case 5:
+                                    Level = "Verbose";
+                                    break;
 
-                    case "Keywords":
+                                case 8:
+                                    Level = "Success";
+                                    break;
+                                case 16:
+                                    Level = "Failure";
+                                    break;
+                                default:
+                                    Level = lvl.ToString();
+                                    break;
+                            }
 
-                        var kw = reader.ReadElementContentAsString();
+                            break;
 
-                        switch (kw)
-                        {
-                            case "0x8010000000000000":
-                                Keywords = "Audit failure";
-                                break;
-                            case "0x8020000000000000":
-                                Keywords = "Audit success";
-                                break;
-                            case "0x8000000000000010":
-                                Keywords = "Time";
-                                break;
-                            case "0x8000000000000080":
-                                Keywords = "State";
-                                break;
-                            case "0x8000000000000040":
-                                Keywords = "Reboot";
-                                break;
-                            case "0x8000000000000018":
-                                Keywords = "Installation";
-                                break;
-                            case "0x8000000000000014":
-                                Keywords = "Download";
-                                break;
-                            case "0x8080000000000000":
-                                Keywords = "Audit success, classic";
-                                break;
-                            case "0x8000000000000000":
-                                Keywords = "Classic";
-                                break;
-                            default:
-                                Keywords = kw;
-                                break;
-                        }
+                        case "Keywords":
 
-                        break;
+                            var kw = reader.ReadElementContentAsString();
 
-                    case "TimeCreated":
-                        var st = reader.GetAttribute("SystemTime");
-                        TimeCreated = DateTimeOffset.Parse(st, null, DateTimeStyles.AssumeUniversal).ToUniversalTime();
-                        break;
-                    case "Provider":
-                        Provider = reader.GetAttribute("Name");
-                        break;
-                    case "Execution":
-                        var pid = reader.GetAttribute("ProcessID");
-                        var tid = reader.GetAttribute("ThreadID");
-                        if (pid!=null)
-                        {
-                            ProcessId = int.Parse(pid);
-                        }
+                            switch (kw)
+                            {
+                                case "0x8010000000000000":
+                                    Keywords = "Audit failure";
+                                    break;
+                                case "0x8020000000000000":
+                                    Keywords = "Audit success";
+                                    break;
+                                case "0x8000000000000010":
+                                    Keywords = "Time";
+                                    break;
+                                case "0x8000000000000080":
+                                    Keywords = "State";
+                                    break;
+                                case "0x8000000000000040":
+                                    Keywords = "Reboot";
+                                    break;
+                                case "0x8000000000000018":
+                                    Keywords = "Installation";
+                                    break;
+                                case "0x8000000000000014":
+                                    Keywords = "Download";
+                                    break;
+                                case "0x8080000000000000":
+                                    Keywords = "Audit success, classic";
+                                    break;
+                                case "0x8000000000000000":
+                                    Keywords = "Classic";
+                                    break;
+                                default:
+                                    Keywords = kw;
+                                    break;
+                            }
 
-                        if (tid != null)
-                        {
-                            ThreadId = int.Parse(tid);
-                        }
-                            
-                        break;
-                    case "Security":
-                        UserId = reader.GetAttribute("UserID");
-                        break;
-                      
-                    case "EventData":
-                    case "UserData":
-                        Payload = reader.ReadOuterXml();
+                            break;
 
-                        break;
+                        case "TimeCreated":
+                            var st = reader.GetAttribute("SystemTime");
+                            TimeCreated = DateTimeOffset.Parse(st, null, DateTimeStyles.AssumeUniversal).ToUniversalTime();
+                            break;
+                        case "Provider":
+                            Provider = reader.GetAttribute("Name");
+                            break;
+                        case "Execution":
+                            var pid = reader.GetAttribute("ProcessID");
+                            var tid = reader.GetAttribute("ThreadID");
+                            if (pid != null)
+                            {
+                                ProcessId = int.Parse(pid);
+                            }
+
+                            if (tid != null)
+                            {
+                                ThreadId = int.Parse(tid);
+                            }
+
+                            break;
+                        case "Security":
+                            UserId = reader.GetAttribute("UserID");
+                            break;
+
+                        case "EventData":
+                        case "UserData":
+                            Payload = reader.ReadOuterXml();
+
+                            break;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning("Record # {RecordNumber}: Unable to parse XML element {ElementName}. Error: {Message}",RecordNumber,reader.Name,ex.Message);
                 }
             }
         }
 
         if (Payload == null)
         {
-            reader = XmlReader.Create(new StringReader(xml));
-            reader.MoveToContent();
+            try
+            {
+                reader = XmlReader.Create(new StringReader(xml));
+                reader.MoveToContent();
 
-            reader.ReadToDescendant("System");
-            reader.ReadOuterXml();
-            reader.ReadOuterXml();
-            Payload=  reader.ReadOuterXml();
+                if (reader.ReadToDescendant("System"))
+                {
+                    reader.ReadOuterXml();
+                    reader.ReadOuterXml();
+                    Payload = reader.ReadOuterXml();
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning("Record # {RecordNumber}: Unable to extract payload data. Error: {Message}",RecordNumber,ex.Message);
+            }
+
+            Payload ??= string.Empty;
 
         }
 

--- a/evtx/EventRecord.cs
+++ b/evtx/EventRecord.cs
@@ -120,6 +120,16 @@ public class EventRecord
     public string Keywords { get; private set; }
     public string SourceFile { get; set; }
 
+    /// <summary>
+    ///     Some providers (e.g. manifest-based/self-describing providers like Microsoft-Windows-Perflib) embed a
+    ///     &lt;RenderingInfo&gt; element alongside &lt;System&gt;. It re-uses several element names found in
+    ///     &lt;System&gt; (Level, Channel, Provider, Keywords, etc.) but with different shapes/content, so it is
+    ///     parsed separately to avoid clobbering the authoritative &lt;System&gt; values. All of its fields are
+    ///     combined into a single JSON blob here, mirroring how <see cref="Payload" /> holds EventData/UserData as a
+    ///     single serialized value.
+    /// </summary>
+    public string RenderingInfo { get; private set; }
+
     public long ExtraDataOffset { get; set; }
     public bool HiddenRecord { get; set; }
 
@@ -146,11 +156,74 @@ public class EventRecord
 
         var reader = XmlReader.Create(new StringReader(xml));
         reader.MoveToContent();
+
+        // Some providers (e.g. manifest-based/self-describing providers like Microsoft-Windows-Perflib) embed a
+        // <RenderingInfo> element alongside <System>. It re-uses several element names from <System> (Level,
+        // Channel, Provider, Keywords, etc.) but with different shapes/content (e.g. Keywords is a list of
+        // <Keyword> child elements instead of a single hex string). It is parsed into its own DTO below so it
+        // never overwrites/corrupts the authoritative <System> values, then combined into a single RenderingInfo
+        // JSON value so its otherwise-unique data (rendered Message, friendly Task name, etc.) isn't silently
+        // discarded.
+        var insideRenderingInfo = false;
+        RenderingInfoData renderingInfoData = null;
+
         // Parse the file and display each of the nodes.
         while (reader.Read())
         {
+            if (reader.NodeType == XmlNodeType.EndElement && reader.Name == "RenderingInfo")
+            {
+                insideRenderingInfo = false;
+                continue;
+            }
+
             if (reader.IsStartElement())
             {
+                if (reader.Name == "RenderingInfo")
+                {
+                    insideRenderingInfo = true;
+                    renderingInfoData ??= new RenderingInfoData();
+                    continue;
+                }
+
+                if (insideRenderingInfo)
+                {
+                    try
+                    {
+                        switch (reader.Name)
+                        {
+                            case "Level":
+                                renderingInfoData.Level = reader.ReadElementContentAsString();
+                                break;
+                            case "Opcode":
+                                renderingInfoData.Opcode = reader.ReadElementContentAsString();
+                                break;
+                            case "Task":
+                                renderingInfoData.Task = reader.ReadElementContentAsString();
+                                break;
+                            case "Channel":
+                                renderingInfoData.Channel = reader.ReadElementContentAsString();
+                                break;
+                            case "Provider":
+                                renderingInfoData.Provider = reader.ReadElementContentAsString();
+                                break;
+                            case "Keywords":
+                                renderingInfoData.Keywords = ReadRenderingInfoKeywords(reader);
+                                break;
+                            case "Message":
+                                renderingInfoData.Message = reader.ReadElementContentAsString();
+                                break;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Warning(
+                            "Record # {RecordNumber}: Unable to parse RenderingInfo XML element {ElementName}. Error: {Message}",
+                            RecordNumber, reader.Name, ex.Message);
+                    }
+
+                    continue;
+                }
+
                 try
                 {
                     switch (reader.Name)
@@ -283,6 +356,11 @@ public class EventRecord
                     Log.Warning("Record # {RecordNumber}: Unable to parse XML element {ElementName}. Error: {Message}",RecordNumber,reader.Name,ex.Message);
                 }
             }
+        }
+
+        if (renderingInfoData != null)
+        {
+            RenderingInfo = renderingInfoData.ToJson();
         }
 
         if (Payload == null)
@@ -452,6 +530,44 @@ public class EventRecord
         }
     }
 
+    /// <summary>
+    ///     RenderingInfo's Keywords element can be either plain text (a single hex bitmask, matching System's shape)
+    ///     or a list of child &lt;Keyword&gt; elements (one per named bit). This reads either shape and returns a
+    ///     comma-separated string of the resolved values.
+    /// </summary>
+    private static string ReadRenderingInfoKeywords(XmlReader reader)
+    {
+        if (reader.IsEmptyElement)
+        {
+            reader.Read();
+            return string.Empty;
+        }
+
+        var keywords = new List<string>();
+
+        using (var subtree = reader.ReadSubtree())
+        {
+            subtree.Read(); // move onto the Keywords start element
+
+            while (subtree.Read())
+            {
+                if (subtree.NodeType == XmlNodeType.Element && subtree.Name == "Keyword")
+                {
+                    keywords.Add(subtree.ReadElementContentAsString());
+                }
+                else if (subtree.NodeType == XmlNodeType.Text)
+                {
+                    keywords.Add(subtree.Value);
+                }
+            }
+        }
+
+        // ReadSubtree leaves the original reader positioned on Keywords' end element, so advance past it
+        reader.Read();
+
+        return string.Join(",", keywords);
+    }
+
     public string ConvertPayloadToXml()
     {
         var ti = Nodes.SingleOrDefault(t => t.TagType == TagBuilder.BinaryTag.TemplateInstance);
@@ -485,4 +601,20 @@ public class EventRecord
         return
             $"Record position: 0x{RecordPosition:X4} Record #: {RecordNumber.ToString().PadRight(3)} Timestamp: {Timestamp:yyyy-MM-dd HH:mm:ss.fffffff} Event ID: {EventId}";
     }
+}
+
+/// <summary>
+///     Holds the fields parsed from a record's optional &lt;RenderingInfo&gt; element. Serialized as a single JSON
+///     blob into <see cref="EventRecord.RenderingInfo" />, mirroring how <see cref="EventRecord.Payload" /> holds
+///     EventData/UserData as a single serialized value.
+/// </summary>
+internal class RenderingInfoData
+{
+    public string Level { get; set; }
+    public string Opcode { get; set; }
+    public string Task { get; set; }
+    public string Channel { get; set; }
+    public string Provider { get; set; }
+    public string Keywords { get; set; }
+    public string Message { get; set; }
 }

--- a/evtx/EventRecord.cs
+++ b/evtx/EventRecord.cs
@@ -537,11 +537,10 @@ public class EventRecord
     /// </summary>
     private static string ReadRenderingInfoKeywords(XmlReader reader)
     {
-        if (reader.IsEmptyElement)
-        {
-            reader.Read();
-            return string.Empty;
-        }
+if (reader.IsEmptyElement)
+{
+    return string.Empty;
+}
 
         var keywords = new List<string>();
 

--- a/evtx/EventRecord.cs
+++ b/evtx/EventRecord.cs
@@ -54,12 +54,17 @@ public class EventRecord
 
                 var found2a = true; //danderspritz test
                 var maxCount = 0;
-                while (recordData.ReadByte() != 0x2a && maxCount<15)
+                while (maxCount < 15)
                 {
                     if (recordData.BaseStream.Position == recordData.BaseStream.Length)
                     {
                         found2a = false;
                         break; //out of data
+                    }
+
+                    if (recordData.ReadByte() == 0x2a)
+                    {
+                        break;
                     }
                     
                     maxCount += 1;
@@ -288,7 +293,14 @@ public class EventRecord
             return;
         }
 
-        if (!EventLog.EventLogMaps.ContainsKey($"{EventId}-{Channel.ToUpperInvariant()}-{Provider.ToUpperInvariant()}"))
+        if (Channel.IsNullOrEmpty() || Provider.IsNullOrEmpty())
+        {
+            return;
+        }
+
+        var mapKey = $"{EventId}-{Channel.ToUpperInvariant()}-{Provider.ToUpperInvariant()}";
+
+        if (!EventLog.EventLogMaps.ContainsKey(mapKey))
         {
             return;
         }
@@ -297,7 +309,7 @@ public class EventRecord
         var nav = docNav.CreateNavigator();
 
         Log.Verbose("Found map for Event ID {EventId} with Channel {Channel} and Provider {Provider}!",EventId,Channel,Provider);
-        var map = EventLog.EventLogMaps[$"{EventId}-{Channel.ToUpperInvariant()}-{Provider.ToUpperInvariant()}"];
+        var map = EventLog.EventLogMaps[mapKey];
 
         MapDescription = map.Description;
 
@@ -432,9 +444,17 @@ public class EventRecord
         ti = (TemplateInstance) ti;
 
         var xmld = new XmlDocument();
-        var rawXml = ti.AsXml(null, RecordPosition).Replace("&", "&amp;");
+        var rawXml = ti.AsXml(null, RecordPosition);
 
-        xmld.LoadXml(rawXml);
+        try
+        {
+            xmld.LoadXml(rawXml);
+        }
+        catch (XmlException)
+        {
+            rawXml = Regex.Replace(rawXml, "&(?!amp;|lt;|gt;|quot;|apos;|#\\d+;|#x[0-9A-Fa-f]+;)", "&amp;");
+            xmld.LoadXml(rawXml);
+        }
 
         return Regex.Replace(xmld.Beautify(), " xmlns.+\">", ">",
             RegexOptions.IgnoreCase | RegexOptions.Multiline);

--- a/evtx/SubstitutionArrayEntry.cs
+++ b/evtx/SubstitutionArrayEntry.cs
@@ -282,7 +282,27 @@ public class SubstitutionArrayEntry
 
             case TagBuilder.ValueType.ArraySids:
             case TagBuilder.ValueType.Array32BitHex:
+                var a32h = new List<string>();
+                index = 0;
+                while (index < DataBytes.Length)
+                {
+                    var ul = BitConverter.ToUInt32(DataBytes, index);
+                    index += 4;
+                    a32h.Add($"0x{ul:X}");
+                }
+
+                return string.Join(",", a32h);
             case TagBuilder.ValueType.Array64BitHex:
+                var a64h = new List<string>();
+                index = 0;
+                while (index < DataBytes.Length)
+                {
+                    var ul = BitConverter.ToUInt64(DataBytes, index);
+                    index += 8;
+                    a64h.Add($"0x{ul:X}");
+                }
+
+                return string.Join(",", a64h);
 
             default:
                 throw new ArgumentOutOfRangeException(

--- a/evtx/Tags/TagBuilder.cs
+++ b/evtx/Tags/TagBuilder.cs
@@ -268,6 +268,7 @@ public static class TagBuilder
                 return new Attribute(recordPosition, dataStream, chunk);
 
             case BinaryTag.Value:
+            case BinaryTag.Value2:
                 return new Value(recordPosition, dataStream, chunk);
 
             case BinaryTag.CloseStartElementTag:

--- a/evtx/Tags/TemplateInstance.cs
+++ b/evtx/Tags/TemplateInstance.cs
@@ -30,7 +30,7 @@ internal class TemplateInstance : IBinXml
 
         if (Template == null)
         {
-            throw new Exception($"Template could not be resolved at offset 0x{templateOffset:X}");
+            throw new InvalidDataException($"Template could not be resolved at offset 0x{templateOffset:X}");
         }
 
         Size = Template.Size;

--- a/evtx/Tags/TemplateInstance.cs
+++ b/evtx/Tags/TemplateInstance.cs
@@ -28,6 +28,11 @@ internal class TemplateInstance : IBinXml
 
         Template = chunk.GetTemplate(templateOffset);
 
+        if (Template == null)
+        {
+            throw new Exception($"Template could not be resolved at offset 0x{templateOffset:X}");
+        }
+
         Size = Template.Size;
         if (templateOffset < recordPosition)
         {

--- a/evtx/Tags/Value.cs
+++ b/evtx/Tags/Value.cs
@@ -38,7 +38,12 @@ public class Value : IBinXml
 
     private string GetValueData(BinaryReader dataStream)
     {
-        var sizeBytes = Size < 0 ? 0 : (int) Size;
+        if (Size < 0)
+        {
+            throw new InvalidDataException($"Invalid value size {Size} for type {ValueDataType}");
+        }
+
+        var sizeBytes = (int) Size;
 
         switch (ValueDataType)
         {

--- a/evtx/Tags/Value.cs
+++ b/evtx/Tags/Value.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using Serilog;
@@ -17,14 +18,7 @@ public class Value : IBinXml
 
         Size = dataStream.ReadInt16();
 
-        switch (ValueDataType)
-        {
-            case TagBuilder.ValueType.StringType:
-                ValueData = Encoding.Unicode.GetString(dataStream.ReadBytes((int) (Size * 2)));
-                break;
-            default:
-                throw new ArgumentOutOfRangeException($"Value Type {ValueDataType} is not handled! Handle it!");
-        }
+        ValueData = GetValueData(dataStream);
 
         Log.Verbose("{This}",this);
     }
@@ -41,6 +35,47 @@ public class Value : IBinXml
     }
 
     public TagBuilder.BinaryTag TagType => TagBuilder.BinaryTag.Value;
+
+    private string GetValueData(BinaryReader dataStream)
+    {
+        var sizeBytes = Size < 0 ? 0 : (int) Size;
+
+        switch (ValueDataType)
+        {
+            case TagBuilder.ValueType.StringType:
+                return Encoding.Unicode.GetString(dataStream.ReadBytes(sizeBytes * 2)).Trim('\0');
+            case TagBuilder.ValueType.AnsiStringType:
+                return Encoding.ASCII.GetString(dataStream.ReadBytes(sizeBytes)).Trim('\0');
+            case TagBuilder.ValueType.Int8Type:
+                return ((sbyte) dataStream.ReadByte()).ToString();
+            case TagBuilder.ValueType.UInt8Type:
+                return dataStream.ReadByte().ToString();
+            case TagBuilder.ValueType.Int16Type:
+                return dataStream.ReadInt16().ToString();
+            case TagBuilder.ValueType.UInt16Type:
+                return dataStream.ReadUInt16().ToString();
+            case TagBuilder.ValueType.Int32Type:
+                return dataStream.ReadInt32().ToString();
+            case TagBuilder.ValueType.UInt32Type:
+                return dataStream.ReadUInt32().ToString();
+            case TagBuilder.ValueType.Int64Type:
+                return dataStream.ReadInt64().ToString();
+            case TagBuilder.ValueType.UInt64Type:
+                return dataStream.ReadUInt64().ToString();
+            case TagBuilder.ValueType.Real32Type:
+                return dataStream.ReadSingle().ToString(CultureInfo.InvariantCulture);
+            case TagBuilder.ValueType.Real64Type:
+                return dataStream.ReadDouble().ToString(CultureInfo.InvariantCulture);
+            case TagBuilder.ValueType.BoolType:
+                return (dataStream.ReadInt32() != 0).ToString();
+            case TagBuilder.ValueType.GuidType:
+                return new Guid(dataStream.ReadBytes(16)).ToString();
+            case TagBuilder.ValueType.BinaryType:
+                return BitConverter.ToString(dataStream.ReadBytes(sizeBytes));
+            default:
+                return BitConverter.ToString(dataStream.ReadBytes(sizeBytes));
+        }
+    }
 
     public override string ToString()
     {


### PR DESCRIPTION
Noticed some of the event logs in TheTechHiveScenario werent parsing properly. They work with evtx_dump (https://github.com/omerbenamram/EVTX) so I gave copilot the task of reviewing the code, comparing with evtx_dump, and re-evaluating against the dataset  (https://github.com/randomaccess3/DFIRArtifactMuseum/tree/main/Windows/EventLogs/Win11/TheTechHiveScenario)

Current version: 
<img width="1898" height="260" alt="image" src="https://github.com/user-attachments/assets/1b96f2f4-1563-4265-ab8d-0ea4a33bffcc" />


This version: 
<img width="572" height="76" alt="image" src="https://github.com/user-attachments/assets/92b835de-2225-49ac-be14-444210b00e4e" />

I havent done more testing than this however.